### PR TITLE
fix: Klip 로그인만 수행한 유저에 대해 isNew 값 상이하게 지정

### DIFF
--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -37,4 +37,12 @@ public class User {
         this.privacyAgreement = privacyAgreement;
         this.isActive = isActive;
     }
+
+    public boolean hasNickname() {
+        return !nickname.isEmpty();
+    }
+
+    public boolean hasPhoneNumber() {
+        return !phoneNumber.isEmpty();
+    }
 }

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -33,11 +33,15 @@ public class UserService {
 
     private UserLoginSuccessResponse completeLogin(String klaytnAddress) {
         Optional<User> optionalUser = userRepository.findByKlaytnAddressAndIsActive(klaytnAddress, true);
-        return optionalUser.map(user -> UserLoginSuccessResponse.of(
-                user,
-                jwtProvider.generateToken(klaytnAddress),
-                false
-        )).orElseGet(() -> completeNewUserLogin(klaytnAddress));
+        return optionalUser.map(user -> completeRegisteredUserLogin(klaytnAddress, user))
+                .orElseGet(() -> completeNewUserLogin(klaytnAddress));
+    }
+
+    private UserLoginSuccessResponse completeRegisteredUserLogin(String klaytnAddress, User user) {
+        if (user.hasNickname() && user.hasPhoneNumber()) {
+            return UserLoginSuccessResponse.of(user, jwtProvider.generateToken(klaytnAddress), false);
+        }
+        return UserLoginSuccessResponse.of(user, jwtProvider.generateToken(klaytnAddress), true);
     }
 
     private UserLoginSuccessResponse completeNewUserLogin(String klaytnAddress) {

--- a/src/test/java/com/backend/connectable/user/domain/UserTest.java
+++ b/src/test/java/com/backend/connectable/user/domain/UserTest.java
@@ -33,4 +33,50 @@ class UserTest {
         assertThat(joel.getPhoneNumber()).isEqualTo(phoneNumber);
         assertThat(joel.isPrivacyAgreement()).isEqualTo(privacyAgreement);
     }
+
+    @DisplayName("닉네임을 유저가 가지고 있는지 검증할 수 있다.")
+    @Test
+    void hasNickname() {
+        // given
+        Long id = 1L;
+        String klaytnAddress = "0x1234";
+        String nickname = "";
+        String phoneNumber = "010-1234-5678";
+        boolean privacyAgreement = true;
+
+        // when
+        User noNickNameUser = User.builder()
+                .id(id)
+                .klaytnAddress(klaytnAddress)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .privacyAgreement(privacyAgreement)
+                .build();
+
+        // then
+        assertThat(noNickNameUser.hasNickname()).isFalse();
+    }
+
+    @DisplayName("유저가 핸드폰 번호를 가지고 있는지 검증할 수 있다.")
+    @Test
+    void hasPhoneNumber() {
+        // given
+        Long id = 1L;
+        String klaytnAddress = "0x1234";
+        String nickname = "nickname";
+        String phoneNumber = "";
+        boolean privacyAgreement = true;
+
+        // when
+        User noNickNameUser = User.builder()
+                .id(id)
+                .klaytnAddress(klaytnAddress)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .privacyAgreement(privacyAgreement)
+                .build();
+
+        // then
+        assertThat(noNickNameUser.hasPhoneNumber()).isFalse();
+    }
 }


### PR DESCRIPTION
## 작업 내용
- Klip 로그인만을 수행한 유저에 대해서는 (전화번호/닉네임 미등록) isNew=true 를 반환하도록 수정

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
