### PR TITLE
feat: ticket 엔티티 구현 및 dataLoader 도입

### DIFF
--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -1,10 +1,10 @@
 package com.backend.connectable;
 
 import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.SalesOption;
 import com.backend.connectable.event.domain.Ticket;
 import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.domain.repository.EventRepository;
-import com.backend.connectable.event.domain.SalesOption;
 import com.backend.connectable.event.domain.repository.TicketRepository;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 
-@Profile({"local", "dev"})
+@Profile("dev")
 @Transactional
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -1,0 +1,125 @@
+package com.backend.connectable;
+
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
+import com.backend.connectable.event.domain.repository.EventRepository;
+import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+
+@Profile({"local", "dev"})
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class DataLoader implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+    private final TicketRepository ticketRepository;
+
+    private static final String EVENT_IMG_URL = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/image_0xtest.jpeg";
+    private static final String EVENT_CONTRACT_ADDRESS = "0xda8E2cdEB663Aa3c3DCf729A2937002C27aA1a81";
+    private static final String JOEL_KLIP = "0x3AB31D219d45CE40d6862d68d37De6BB73E21a8D";
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        User joel = User.builder()
+                .klaytnAddress(JOEL_KLIP)
+                .nickname("조엘")
+                .phoneNumber("01012345678")
+                .privacyAgreement(true)
+                .isActive(true)
+                .build();
+        userRepository.save(joel);
+
+        Event joelEvent = Event.builder()
+                .description("조엘의 콘서트 at Connectable")
+                .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+                .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+                .contractAddress(EVENT_CONTRACT_ADDRESS)
+                .eventName("조엘의 콘서트")
+                .eventImage(EVENT_IMG_URL)
+                .twitterUrl("https://github.com/joelonsw")
+                .instagramUrl("https://www.instagram.com/jyoung_with/")
+                .webpageUrl("https://papimon.tistory.com/")
+                .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+                .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+                .salesOption(SalesOption.FLAT_PRICE)
+                .build();
+        eventRepository.save(joelEvent);
+
+        TicketMetadata joelTicket1Metadata = TicketMetadata.builder()
+                .name("조엘 콘서트 #1")
+                .description("조엘의 콘서트 at Connectable")
+                .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test1.png")
+                .attributes(new HashMap<>(){{
+                    put("Background", "Yellow");
+                    put("Artist", "Joel");
+                    put("Seat", "A6");
+                }})
+                .build();
+
+        Ticket joelTicket1 = Ticket.builder()
+                .user(joel)
+                .event(joelEvent)
+                .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
+                .price(100000)
+                .onSale(true)
+                .ticketMetadata(joelTicket1Metadata)
+                .build();
+
+        TicketMetadata joelTicket2Metadata = TicketMetadata.builder()
+                .name("조엘 콘서트 #2")
+                .description("조엘의 콘서트 at Connectable")
+                .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test2.png")
+                .attributes(new HashMap<>(){{
+                    put("Background", "Yellow");
+                    put("Artist", "Joel");
+                    put("Seat", "A5");
+                }})
+                .build();
+
+        Ticket joelTicket2 = Ticket.builder()
+                .user(joel)
+                .event(joelEvent)
+                .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
+                .price(100000)
+                .onSale(true)
+                .ticketMetadata(joelTicket2Metadata)
+                .build();
+
+        TicketMetadata joelTicket3Metadata = TicketMetadata.builder()
+                .name("조엘 콘서트 #3")
+                .description("조엘의 콘서트 at Connectable")
+                .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test3.png")
+                .attributes(new HashMap<>(){{
+                    put("Background", "Yellow");
+                    put("Artist", "Joel");
+                    put("Seat", "A4");
+                }})
+                .build();
+
+        Ticket joelTicket3 = Ticket.builder()
+                .user(joel)
+                .event(joelEvent)
+                .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/3.json")
+                .price(100000)
+                .onSale(true)
+                .ticketMetadata(joelTicket3Metadata)
+                .build();
+
+        ticketRepository.saveAll(Arrays.asList(joelTicket1, joelTicket2, joelTicket3));
+    }
+}

--- a/src/main/java/com/backend/connectable/event/domain/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/EventRepositoryCustom.java
@@ -1,4 +1,0 @@
-package com.backend.connectable.event.domain;
-
-public interface EventRepositoryCustom {
-}

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -1,0 +1,50 @@
+package com.backend.connectable.event.domain;
+
+import com.backend.connectable.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private Event event;
+
+    private int tokenId;
+
+    private String tokenUri;
+
+    private int price;
+
+    private boolean onSale;
+
+    @Convert(converter = TicketMetadataConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private TicketMetadata ticketMetadata;
+
+    @Builder
+    public Ticket(Long id, User user, Event event, int tokenId, String tokenUri, int price, boolean onSale, TicketMetadata ticketMetadata) {
+        this.id = id;
+        this.user = user;
+        this.event = event;
+        this.tokenId = tokenId;
+        this.tokenUri = tokenUri;
+        this.price = price;
+        this.onSale = onSale;
+        this.ticketMetadata = ticketMetadata;
+    }
+}

--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadata.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadata.java
@@ -1,0 +1,33 @@
+package com.backend.connectable.event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketMetadata {
+    private String name;
+    private String description;
+    private String image;
+    private List<TicketMetadataAttribute> attributes;
+
+    @Builder
+    public TicketMetadata(String name, String description, String image, Map<String, String> attributes) {
+        this.name = name;
+        this.description = description;
+        this.image = image;
+        this.attributes = attributes.entrySet().stream()
+                .map(attribute -> TicketMetadataAttribute.builder()
+                        .trait_type(attribute.getKey())
+                        .value(attribute.getValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadataAttribute.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadataAttribute.java
@@ -1,0 +1,15 @@
+package com.backend.connectable.event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketMetadataAttribute {
+    private String trait_type;
+    private String value;
+}

--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadataConverter.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadataConverter.java
@@ -1,0 +1,32 @@
+package com.backend.connectable.event.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.persistence.AttributeConverter;
+import java.io.IOException;
+
+public class TicketMetadataConverter implements AttributeConverter<TicketMetadata, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Override
+    public String convertToDatabaseColumn(TicketMetadata attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("티켓 메타데이터 -> JSON 실패");
+        }
+    }
+
+    @Override
+    public TicketMetadata convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, TicketMetadata.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("JSON -> 티켓 메타데이터 실패");
+        }
+    }
+}

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepository.java
@@ -1,5 +1,6 @@
-package com.backend.connectable.event.domain;
+package com.backend.connectable.event.domain.repository;
 
+import com.backend.connectable.event.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.backend.connectable.event.domain.repository;
+
+public interface EventRepositoryCustom {
+}

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.backend.connectable.event.domain;
+package com.backend.connectable.event.domain.repository;
 
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package com.backend.connectable.event.domain.repository;
+
+import com.backend.connectable.event.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -1,6 +1,6 @@
 package com.backend.connectable.event.service;
 
-import com.backend.connectable.event.domain.EventRepository;
+import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
+++ b/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.security;
 
 import com.backend.connectable.user.domain.User;
-import com.backend.connectable.user.domain.UserRepository;
+import com.backend.connectable.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
-package com.backend.connectable.user.domain;
+package com.backend.connectable.user.domain.repository;
 
 
+import com.backend.connectable.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.backend.connectable.user.domain;
+package com.backend.connectable.user.domain.repository;
 
 public interface UserRepositoryCustom {
 

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.backend.connectable.user.domain;
+package com.backend.connectable.user.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
 import com.backend.connectable.security.ConnectableUserDetails;
 import com.backend.connectable.security.JwtProvider;
 import com.backend.connectable.user.domain.User;
-import com.backend.connectable.user.domain.UserRepository;
+import com.backend.connectable.user.domain.repository.UserRepository;
 import com.backend.connectable.user.ui.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.backend.connectable.event.domain.repository;
+
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TicketRepositoryTest {
+
+    @Autowired
+    TicketRepository ticketRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    EntityManager em;
+
+    User joel = User.builder()
+            .klaytnAddress("0x1234")
+            .nickname("Joel")
+            .phoneNumber("010-1234-5678")
+            .privacyAgreement(true)
+            .isActive(true)
+            .build();
+
+    Event joelEvent = Event.builder()
+            .description("조엘의 콘서트 at Connectable")
+            .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+            .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+            .contractAddress("0x123456")
+            .eventName("조엘의 콘서트")
+            .eventImage("https://image.url")
+            .twitterUrl("https://github.com/joelonsw")
+            .instagramUrl("https://www.instagram.com/jyoung_with/")
+            .webpageUrl("https://papimon.tistory.com/")
+            .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+            .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+            .salesOption(SalesOption.FLAT_PRICE)
+            .build();
+
+    TicketMetadata joelTicket1Metadata = TicketMetadata.builder()
+            .name("조엘 콘서트 #1")
+            .description("조엘의 콘서트 at Connectable")
+            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test1.png")
+            .attributes(new HashMap<>(){{
+                put("Background", "Yellow");
+                put("Artist", "Joel");
+                put("Seat", "A6");
+            }})
+            .build();
+
+    Ticket joelTicket1 = Ticket.builder()
+            .user(joel)
+            .event(joelEvent)
+            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
+            .price(100000)
+            .onSale(true)
+            .ticketMetadata(joelTicket1Metadata)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(joel);
+        eventRepository.save(joelEvent);
+    }
+
+    @DisplayName("Ticket을 저장할 수 있다.")
+    @Test
+    void saveTicket() {
+        // given & when
+        Ticket savedTicket = ticketRepository.save(joelTicket1);
+
+        // then
+        assertThat(savedTicket.getUser()).isEqualTo(joel);
+        assertThat(savedTicket.getEvent()).isEqualTo(joelEvent);
+        assertThat(savedTicket.getPrice()).isEqualTo(100000);
+        assertThat(savedTicket.isOnSale()).isEqualTo(true);
+        assertThat(savedTicket.getTicketMetadata().getName()).isEqualTo("조엘 콘서트 #1");
+        assertThat(savedTicket.getTicketMetadata().getAttributes()).hasSize(3);
+    }
+}

--- a/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
+++ b/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.service;
 
 import com.backend.connectable.event.domain.Event;
-import com.backend.connectable.event.domain.EventRepository;
+import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/backend/connectable/user/domain/UserRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/user/domain/UserRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.user.domain;
 
+import com.backend.connectable.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -4,7 +4,7 @@ import com.backend.connectable.klip.service.KlipService;
 import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
 import com.backend.connectable.security.ConnectableUserDetails;
 import com.backend.connectable.user.domain.User;
-import com.backend.connectable.user.domain.UserRepository;
+import com.backend.connectable.user.domain.repository.UserRepository;
 import com.backend.connectable.user.ui.dto.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 작업 내용
**1. Ticket 엔티티를 만들었어요**
  - Event 도메인 패키지 하위에서 작업했습니다
  - Artist 도메인을 아직 만들지 않아서 추후 작업 후 매핑이 필요해보여요
  - JSON을 저장하기 위해 TicketMetadataConverter를 만들었어요
    - 여기서 JSON <-> Object 를 변환해줍니다
    - TicketMetadata, TicketMetadataAttribute가 매핑되는 Object에요
    - 작업에 참고한 자료 : https://goslim56.tistory.com/21
 - Ticket 도메인 안에 TicketMetadata를 넣어줘서 생성해야 합니다. 따라서 생성자가 조금 복잡하게 생겼어요! 읽고 수정이 필요해보이면 알려주세요 :)

**2. Repository 클래스를 domain 하위의 repository 패키지를 만들어 이동했어요**
  - Domain 패키지에 너무 많은 정보가 담기는 것 같아 따로 이동을 해뒀습니다! 별로면 얘기해주세요!

**3. DataLoader 생성**
  - local, dev 프로파일에 한해 data를 로딩할 수 있는 설정을 붙여뒀습니다. 
    - 테스트를 돌려보니, local profile에 dataloader를 붙여두면 테스트에서도 dataloader 설정들이 db에 반영되는 바람에 테스트에 영향을 주더군요! dev 환경에서만 dataloader 사용토록 수정했습니다. 
  - Postman으로 GET /events 를 해보니 잘 나오더군요!

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
