### PR TITLE
fix: 유저 상세 조회시 status 추가

### DIFF
--- a/src/main/java/com/backend/connectable/user/ui/dto/UserResponse.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserResponse.java
@@ -12,12 +12,14 @@ import lombok.Setter;
 @Setter
 public class UserResponse {
 
+    private String status;
     private String nickname;
     private String phoneNumber;
     private String klaytnAddress;
 
     public static UserResponse of(User user) {
         return new UserResponse(
+                "success",
                 user.getNickname(),
                 user.getPhoneNumber(),
                 user.getKlaytnAddress()

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -78,6 +78,7 @@ class UserServiceTest {
         UserResponse userResponse = userService.getUserByUserDetails(connectableUserDetails);
 
         // then
+        assertThat(userResponse.getStatus()).isEqualTo("success");
         assertThat(userResponse.getNickname()).isEqualTo(user1.getNickname());
         assertThat(userResponse.getKlaytnAddress()).isEqualTo(user1.getKlaytnAddress());
         assertThat(userResponse.getPhoneNumber()).isEqualTo(user1.getPhoneNumber());


### PR DESCRIPTION
## 작업 내용
- 유저 상세 조회시 ResponseBody에 status=success 필드 추가

## 주의 사항
- 조회 실패시 추후 예외처리를 고려하여, 성공 케이스로 하드코딩 되어있음

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
