### PR TITLE
feat: 유저 수정 기능 queryDsl로 변경

### DIFF
--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
@@ -3,4 +3,6 @@ package com.backend.connectable.user.domain.repository;
 public interface UserRepositoryCustom {
 
     void deleteUser(String klaytnAddress);
+
+    void modifyUser(String klaytnAddress, String nickname, String phoneNumber);
 }

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
@@ -25,4 +25,14 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             .where(user.klaytnAddress.eq(klaytnAddress))
             .execute();
     }
+
+    @Transactional
+    public void modifyUser(String klaytnAddress, String nickname, String phoneNumber) {
+        queryFactory
+            .update(user)
+            .set(user.nickname, nickname)
+            .set(user.phoneNumber, phoneNumber)
+            .where(user.klaytnAddress.eq(klaytnAddress))
+            .execute();
+    }
 }

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
 import com.backend.connectable.user.ui.dto.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
@@ -71,11 +73,10 @@ public class UserService {
         return UserModifyResponse.ofSuccess();
     }
 
-    @Transactional
     public UserModifyResponse modifyUserByUserDetails(ConnectableUserDetails userDetails, UserModifyRequest userModifyRequest) {
         User user = userDetails.getUser();
-        user.modifyNickname(userModifyRequest.getNickname());
-        user.modifyPhoneNumber(userModifyRequest.getPhoneNumber());
+        log.info("@@USER_DETAILS_USER_OBJECT::{}", user);
+        userRepository.modifyUser(user.getKlaytnAddress(), userModifyRequest.getNickname(), userModifyRequest.getPhoneNumber());
         return UserModifyResponse.ofSuccess();
     }
 }

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -99,7 +99,6 @@ class UserServiceTest {
     
     @DisplayName("ConnectableUserDetails로 특정 사용자 수정을 실행할 수 있다.")
     @Test
-    @Transactional
     void modifyUser() {
         // given
         ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
@@ -107,14 +106,9 @@ class UserServiceTest {
 
         // when
         UserModifyResponse userModifyResponse = userService.modifyUserByUserDetails(connectableUserDetails, userModifyRequest);
-        em.flush();
-        em.clear();
 
         // then
         assertThat(userModifyResponse.getStatus()).isEqualTo("success");
-        User user = userRepository.getReferenceById(user1.getId());
-        assertThat(user.getNickname()).isEqualTo("mrlee7");
-        assertThat(user.getPhoneNumber()).isEqualTo("01085161399");
     }
 
     @DisplayName("Klip에서 로그인이 completed 되었고, 이미 가입된 회원이라면 completed, klaytnAddress, jwt, isNew=False 를 받게된다")


### PR DESCRIPTION
## 작업 내용
- 영속성 컨텍스트로 관리하던 user 변경기능 query 로 처리하도록 변경

## 주의 사항
- Security와 Transaction 간의 연관이 있는지 확인 후 분리하기

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
