### PR TITLE
feat: 이벤트 조회 api

### DIFF
--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -1,7 +1,11 @@
 package com.backend.connectable;
 
+import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
-import com.backend.connectable.event.domain.*;
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.domain.repository.TicketRepository;
 import com.backend.connectable.user.domain.User;

--- a/src/main/java/com/backend/connectable/artist/domain/Artist.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Artist.java
@@ -1,4 +1,4 @@
-package com.backend.connectable.event.domain;
+package com.backend.connectable.artist.domain;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepository.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepository.java
@@ -1,6 +1,6 @@
 package com.backend.connectable.artist.domain.repository;
 
-import com.backend.connectable.event.domain.Artist;
+import com.backend.connectable.artist.domain.Artist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArtistRepository extends JpaRepository<Artist, Long> {

--- a/src/main/java/com/backend/connectable/event/domain/Event.java
+++ b/src/main/java/com/backend/connectable/event/domain/Event.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.event.domain;
 
+import com.backend.connectable.artist.domain.Artist;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -1,6 +1,8 @@
 package com.backend.connectable.event.domain;
 
 import com.backend.connectable.user.domain.User;
+import com.querydsl.core.annotations.PropertyType;
+import com.querydsl.core.annotations.QueryType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,6 +34,7 @@ public class Ticket {
 
     private boolean onSale;
 
+    @QueryType(PropertyType.STRING)
     @Convert(converter = TicketMetadataConverter.class)
     @Column(columnDefinition = "TEXT")
     private TicketMetadata ticketMetadata;

--- a/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class EventTickets {
+public class EventTicket {
 
     private Long id;
     private int price;
@@ -22,4 +22,5 @@ public class EventTickets {
     private int tokenId;
     private String tokenUri;
     private String metadata;
+    private String contractAddress;
 }

--- a/src/main/java/com/backend/connectable/event/domain/dto/EventTickets.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventTickets.java
@@ -1,0 +1,25 @@
+package com.backend.connectable.event.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventTickets {
+
+    private Long id;
+    private int price;
+    private String artistName;
+    private LocalDateTime eventDate;
+    private String eventName;
+    private boolean onSale;
+    private int tokenId;
+    private String tokenUri;
+    private String metadata;
+}

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -1,8 +1,13 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
+import com.backend.connectable.event.domain.dto.EventTickets;
+
+import java.util.List;
 
 public interface EventRepositoryCustom {
 
     EventDetail findEventDetailByEventId(Long eventId);
+
+    List<EventTickets> findAllTickets(Long eventId);
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
-import com.backend.connectable.event.domain.dto.EventTickets;
+import com.backend.connectable.event.domain.dto.EventTicket;
 
 import java.util.List;
 
@@ -9,5 +9,7 @@ public interface EventRepositoryCustom {
 
     EventDetail findEventDetailByEventId(Long eventId);
 
-    List<EventTickets> findAllTickets(Long eventId);
+    List<EventTicket> findAllTickets(Long eventId);
+
+    EventTicket findTicketByEventIdAndTicketId(Long eventId, Long ticketId);
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
-import com.backend.connectable.event.domain.dto.EventTickets;
+import com.backend.connectable.event.domain.dto.EventTicket;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -58,9 +58,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     }
 
     @Override
-    public List<EventTickets> findAllTickets(Long eventId) {
-        List<EventTickets> eventTickets = queryFactory.select(Projections.bean(
-            EventTickets.class,
+    public List<EventTicket> findAllTickets(Long eventId) {
+        List<EventTicket> eventTickets = queryFactory.select(Projections.bean(
+            EventTicket.class,
             ticket.id,
             ticket.price,
             artist.artistName,
@@ -78,5 +78,28 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .groupBy(ticket.id)
             .fetch();
         return eventTickets;
+    }
+
+    @Override
+    public EventTicket findTicketByEventIdAndTicketId(Long eventId, Long ticketId) {
+        return queryFactory.select(Projections.bean(
+            EventTicket.class,
+            ticket.id,
+            ticket.price,
+            artist.artistName,
+            event.startTime.as("eventDate"),
+            event.eventName,
+            ticket.onSale,
+            ticket.tokenId,
+            ticket.tokenUri,
+            ticket.ticketMetadata,
+            event.contractAddress
+            ))
+            .from(event)
+            .innerJoin(ticket).on(ticket.event.id.eq(event.id))
+            .innerJoin(artist).on(event.artist.id.eq(artist.id))
+            .where(ticket.event.id.eq(eventId)
+                .and(ticket.id.eq(ticketId)))
+            .fetchOne();
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
+import com.backend.connectable.event.domain.dto.EventTickets;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -8,8 +9,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.List;
 
-import static com.backend.connectable.event.domain.QArtist.artist;
+import static com.backend.connectable.artist.domain.QArtist.artist;
 import static com.backend.connectable.event.domain.QEvent.event;
 import static com.backend.connectable.event.domain.QTicket.ticket;
 
@@ -53,5 +55,28 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .groupBy(event.id)
             .limit(1)
             .fetchOne();
+    }
+
+    @Override
+    public List<EventTickets> findAllTickets(Long eventId) {
+        List<EventTickets> eventTickets = queryFactory.select(Projections.bean(
+            EventTickets.class,
+            ticket.id,
+            ticket.price,
+            artist.artistName,
+            event.startTime.as("eventDate"),
+            event.eventName,
+            ticket.onSale,
+            ticket.tokenId,
+            ticket.tokenUri,
+            ticket.ticketMetadata
+        ))
+            .from(event)
+            .innerJoin(ticket).on(ticket.event.id.eq(event.id))
+            .innerJoin(artist).on(event.artist.id.eq(artist.id))
+            .where(ticket.event.id.eq(eventId))
+            .groupBy(ticket.id)
+            .fetch();
+        return eventTickets;
     }
 }

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -1,9 +1,11 @@
 package com.backend.connectable.event.service;
 
-import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.domain.dto.EventDetail;
+import com.backend.connectable.event.domain.dto.EventTickets;
+import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
+import com.backend.connectable.event.ui.dto.TicketResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -54,5 +56,22 @@ public class EventService {
                 .build();
 
         return result;
+    }
+
+    public List<TicketResponse> getTicketList(Long eventId) {
+        List<EventTickets> eventTickets = eventRepository.findAllTickets(eventId);
+        return eventTickets.stream()
+            .map(ticket -> TicketResponse.builder()
+                .id(ticket.getId())
+                .price(ticket.getPrice())
+                .artistName(ticket.getArtistName())
+                .eventDate(ticket.getEventDate())
+                .eventName(ticket.getEventName())
+                .onSale(ticket.isOnSale())
+                .tokenId(ticket.getTokenId())
+                .tokenUri(ticket.getTokenUri())
+                .metadata(ticket.getMetadata())
+                .build())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.service;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
-import com.backend.connectable.event.domain.dto.EventTickets;
+import com.backend.connectable.event.domain.dto.EventTicket;
 import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
@@ -59,7 +59,7 @@ public class EventService {
     }
 
     public List<TicketResponse> getTicketList(Long eventId) {
-        List<EventTickets> eventTickets = eventRepository.findAllTickets(eventId);
+        List<EventTicket> eventTickets = eventRepository.findAllTickets(eventId);
         return eventTickets.stream()
             .map(ticket -> TicketResponse.builder()
                 .id(ticket.getId())
@@ -73,5 +73,20 @@ public class EventService {
                 .metadata(ticket.getMetadata())
                 .build())
             .collect(Collectors.toList());
+    }
+
+    public TicketResponse getTicketInfo(Long eventId, Long ticketId) {
+        EventTicket eventTicket = eventRepository.findTicketByEventIdAndTicketId(eventId, ticketId);
+        return TicketResponse.builder()
+            .id(eventTicket.getId())
+            .price(eventTicket.getPrice())
+            .artistName(eventTicket.getArtistName())
+            .eventDate(eventTicket.getEventDate())
+            .eventName(eventTicket.getEventName())
+            .tokenId(eventTicket.getTokenId())
+            .tokenUri(eventTicket.getTokenUri())
+            .metadata(eventTicket.getMetadata())
+            .contractAddress(eventTicket.getContractAddress())
+            .build();
     }
 }

--- a/src/main/java/com/backend/connectable/event/ui/EventController.java
+++ b/src/main/java/com/backend/connectable/event/ui/EventController.java
@@ -3,6 +3,7 @@ package com.backend.connectable.event.ui;
 import com.backend.connectable.event.service.EventService;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
+import com.backend.connectable.event.ui.dto.TicketResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,5 +29,11 @@ public class EventController {
     public ResponseEntity<EventDetailResponse> getEventDetail(@PathVariable("id") Long eventId) {
         EventDetailResponse eventDetailResponse = eventService.getEventDetail(eventId);
         return ResponseEntity.ok(eventDetailResponse);
+    }
+
+    @GetMapping("/{id}/tickets")
+    public List<TicketResponse> getTicketList(@PathVariable("id") Long eventId) {
+        List<TicketResponse> ticketResponse = eventService.getTicketList(eventId);
+        return ticketResponse;
     }
 }

--- a/src/main/java/com/backend/connectable/event/ui/EventController.java
+++ b/src/main/java/com/backend/connectable/event/ui/EventController.java
@@ -36,4 +36,10 @@ public class EventController {
         List<TicketResponse> ticketResponse = eventService.getTicketList(eventId);
         return ticketResponse;
     }
+
+    @GetMapping("/{event-id}/tickets/{ticket-id}")
+    public TicketResponse getTicketInfo(@PathVariable("event-id") Long eventId, @PathVariable("ticket-id") Long ticketId) {
+        TicketResponse ticketResponse = eventService.getTicketInfo(eventId, ticketId);
+        return ticketResponse;
+    }
 }

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
@@ -20,9 +20,10 @@ public class TicketResponse {
     private int tokenId;
     private String tokenUri;
     private String metadata;
+    private String contractAddress;
 
     @Builder
-    public TicketResponse(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, String metadata) {
+    public TicketResponse(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, String metadata, String contractAddress) {
         this.id = id;
         this.price = price;
         this.artistName = artistName;
@@ -32,5 +33,6 @@ public class TicketResponse {
         this.tokenId = tokenId;
         this.tokenUri = tokenUri;
         this.metadata = metadata;
+        this.contractAddress = contractAddress;
     }
 }

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
@@ -1,0 +1,36 @@
+package com.backend.connectable.event.ui.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketResponse {
+
+    private Long id;
+    private int price;
+    private String artistName;
+    private Long eventDate;
+    private String eventName;
+    private boolean onSale;
+    private int tokenId;
+    private String tokenUri;
+    private String metadata;
+
+    @Builder
+    public TicketResponse(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, String metadata) {
+        this.id = id;
+        this.price = price;
+        this.artistName = artistName;
+        this.eventDate = eventDate.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond() * 1000L;
+        this.eventName = eventName;
+        this.onSale = onSale;
+        this.tokenId = tokenId;
+        this.tokenUri = tokenUri;
+        this.metadata = metadata;
+    }
+}

--- a/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
@@ -1,7 +1,11 @@
 package com.backend.connectable.event.domain.repository;
 
+import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
-import com.backend.connectable.event.domain.*;
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
+++ b/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.service;
 
+import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
-import com.backend.connectable.event.domain.Artist;
 import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.ui.dto.EventResponse;


### PR DESCRIPTION
## 작업 내용
- 이벤트에 귀속된 티켓 목록 조회 api
- 특정 티켓 상세 조회 api

+) Get 메소드로 조회하는 경우 비즈니스 로직이 들어가있지 않아 통합테스트로 충분하다 판단하였습니다. 
+) 경로는 [링크](https://blog.restcase.com/7-rules-for-rest-api-uri-design/) 에 따라 camelCase가 아닌 hyphen을 사용하였습니다. 

## 주의 사항
- 데이터의 nullable 조건에 따라 논리적 Join 검토 필요
- TicketMetadata가 null로 내려오는 현상 fix 필요 
ㄴ [@QueryType](http://querydsl.com/static/querydsl/5.0.0/reference/html_single/)로 타입을 강제할 수 있지않을까 하였으나, DB에 Text 타입과 String 타입을 매핑했음에도 값이 null로 내려옵니다.
ㄴ [Reference](https://github.com/querydsl/querydsl/issues/2652)


## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
