### PR TITLE
refactor: 티켓 도메인 쿼리 인덴트 수정 및 QueryProjection 적용, User metadata fix

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.event.domain.dto;
 
 import com.backend.connectable.event.domain.TicketMetadata;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class EventTicket {
 
     private Long id;
@@ -26,4 +25,18 @@ public class EventTicket {
     @Convert(converter = TicketMetadata.class)
     private TicketMetadata metadata;
     private String contractAddress;
+
+    @QueryProjection
+    public EventTicket(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, TicketMetadata metadata, String contractAddress) {
+        this.id = id;
+        this.price = price;
+        this.artistName = artistName;
+        this.eventDate = eventDate;
+        this.eventName = eventName;
+        this.onSale = onSale;
+        this.tokenId = tokenId;
+        this.tokenUri = tokenUri;
+        this.metadata = metadata;
+        this.contractAddress = contractAddress;
+    }
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.dto.EventDetail;
 import com.backend.connectable.event.domain.dto.EventTicket;
+import com.backend.connectable.event.domain.dto.QEventTicket;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -27,27 +28,27 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     @Override
     public EventDetail findEventDetailByEventId(Long eventId) {
         return queryFactory.select(Projections.bean(
-                EventDetail.class,
-                event.id,
-                event.eventName,
-                event.eventImage,
-                artist.artistName,
-                artist.artistImage,
-                event.startTime,
-                event.endTime,
-                event.description,
-                event.salesFrom,
-                event.salesTo,
-                event.twitterUrl,
-                event.instagramUrl,
-                event.webpageUrl,
-                ticket.count().intValue().as("totalTicketCount"),
-                ExpressionUtils.as(
-                    JPAExpressions.select(ticket.count().intValue()).from(ticket).where(ticket.onSale.eq(true))
-                , "onSaleTicketCount"),
-                ticket.price,
-                event.location,
-                event.salesOption
+            EventDetail.class,
+            event.id,
+            event.eventName,
+            event.eventImage,
+            artist.artistName,
+            artist.artistImage,
+            event.startTime,
+            event.endTime,
+            event.description,
+            event.salesFrom,
+            event.salesTo,
+            event.twitterUrl,
+            event.instagramUrl,
+            event.webpageUrl,
+            ticket.count().intValue().as("totalTicketCount"),
+            ExpressionUtils.as(
+                JPAExpressions.select(ticket.count().intValue()).from(ticket).where(ticket.onSale.eq(true))
+            , "onSaleTicketCount"),
+            ticket.price,
+            event.location,
+            event.salesOption
             ))
             .from(event)
             .innerJoin(ticket).on(ticket.event.id.eq(event.id))
@@ -60,8 +61,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
 
     @Override
     public List<EventTicket> findAllTickets(Long eventId) {
-        List<EventTicket> eventTickets = queryFactory.select(Projections.constructor(
-            EventTicket.class,
+        return queryFactory.select(new QEventTicket(
             ticket.id,
             ticket.price,
             artist.artistName,
@@ -72,20 +72,18 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             ticket.tokenUri,
             ticket.ticketMetadata,
             event.contractAddress.as("contractAddress")
-        ))
+            ))
             .from(event)
             .innerJoin(ticket).on(ticket.event.id.eq(event.id))
             .innerJoin(artist).on(event.artist.id.eq(artist.id))
             .where(ticket.event.id.eq(eventId))
             .groupBy(ticket.id)
             .fetch();
-        return eventTickets;
     }
 
     @Override
     public EventTicket findTicketByEventIdAndTicketId(Long eventId, Long ticketId) {
-        return queryFactory.select(Projections.constructor(
-            EventTicket.class,
+        return queryFactory.select(new QEventTicket(
             ticket.id,
             ticket.price,
             artist.artistName,

--- a/src/main/java/com/backend/connectable/user/domain/dto/UserTicket.java
+++ b/src/main/java/com/backend/connectable/user/domain/dto/UserTicket.java
@@ -1,10 +1,13 @@
 package com.backend.connectable.user.domain.dto;
 
+import com.backend.connectable.event.domain.TicketMetadata;
+import com.backend.connectable.event.domain.TicketMetadataConverter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.persistence.Convert;
 import java.time.LocalDateTime;
 
 @Getter
@@ -20,7 +23,8 @@ public class UserTicket {
     private boolean onSale;
     private int tokenId;
     private String tokenUri;
-    private String metadata;
+    @Convert(converter = TicketMetadataConverter.class)
+    private TicketMetadata metadata;
     private String contractAddress;
     private Long eventId;
 }

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
@@ -43,7 +43,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
     @Override
     public List<UserTicket> getOwnTicketsByUser(Long userId) {
-        List<UserTicket> userTickets = queryFactory.select(Projections.constructor(
+        return queryFactory.select(Projections.constructor(
             UserTicket.class,
             ticket.id,
             ticket.price,
@@ -55,12 +55,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             ticket.ticketMetadata,
             event.contractAddress,
             event.id.as("eventId")
-        ))
+            ))
             .from(ticket)
             .leftJoin(user).on(user.id.eq(ticket.user.id))
             .innerJoin(event).on(ticket.event.id.eq(event.id))
             .where(user.id.eq(userId))
             .fetch();
-        return userTickets;
     }
 }

--- a/src/main/java/com/backend/connectable/user/ui/dto/UserTicketResponse.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserTicketResponse.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.user.ui.dto;
 
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.global.common.util.DateTimeUtil;
 import lombok.*;
 
@@ -18,12 +19,12 @@ public class UserTicketResponse {
     private boolean onSale;
     private int tokenId;
     private String tokenUri;
-    private String metadata;
+    private TicketMetadata metadata;
     private String contractAddress;
     private Long eventId;
 
     @Builder
-    public UserTicketResponse(Long id, int price, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, String metadata, String contractAddress, Long eventId) {
+    public UserTicketResponse(Long id, int price, LocalDateTime eventDate, String eventName, boolean onSale, int tokenId, String tokenUri, TicketMetadata metadata, String contractAddress, Long eventId) {
         this.id = id;
         this.price = price;
         this.eventDate = DateTimeUtil.toEpochMilliSeconds(eventDate);


### PR DESCRIPTION
## 작업 내용
- 일부 쿼리 QueryProjection 적용
ㄴ 필드가 많은 쿼리의 경우는 순서 잘못 기입되는 이슈를 우려하여, bean 프로젝션으로 남겨두었습니다. 
- 인덴트 잘못된 부분 수정
- User metadata fix

## 주의 사항
- Service 레이어에서 DTO trans 하는 부분 DTO 로 끌고 들어가는 부분에 대해서는 수요일까지 조금 더 고민해보겠습니다 :) 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
