### PR TITLE
fix: 티켓 메타데이터 dto 도입

### DIFF
--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataAttributeResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataAttributeResponse.java
@@ -1,0 +1,31 @@
+package com.backend.connectable.event.ui.dto;
+
+import com.backend.connectable.event.domain.TicketMetadataAttribute;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketMetadataAttributeResponse {
+
+    private String trait_type;
+    private String value;
+
+    public static TicketMetadataAttributeResponse of(TicketMetadataAttribute attribute) {
+        return new TicketMetadataAttributeResponse(
+                attribute.getTrait_type(),
+                attribute.getValue()
+        );
+    }
+
+    public static List<TicketMetadataAttributeResponse> toList(List<TicketMetadataAttribute> attributes) {
+        return attributes.stream()
+                .map(TicketMetadataAttributeResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataResponse.java
@@ -1,0 +1,29 @@
+package com.backend.connectable.event.ui.dto;
+
+import com.backend.connectable.event.domain.TicketMetadata;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketMetadataResponse {
+
+    private String name;
+    private String description;
+    private String image;
+    private List<TicketMetadataAttributeResponse> attributes;
+
+    public static TicketMetadataResponse of(TicketMetadata metadata) {
+        return new TicketMetadataResponse(
+                metadata.getName(),
+                metadata.getDescription(),
+                metadata.getImage(),
+                TicketMetadataAttributeResponse.toList(metadata.getAttributes())
+        );
+    }
+}

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
@@ -20,14 +20,14 @@ public class TicketResponse {
     private boolean onSale;
     private int tokenId;
     private String tokenUri;
-    private TicketMetadata metadata;
+    private TicketMetadataResponse metadata;
     private String contractAddress;
 
     private String ownedBy;
 
     @Builder
     public TicketResponse(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, boolean onSale,
-                          int tokenId, String tokenUri, String metadata, String contractAddress, String ownedBy) {
+                          int tokenId, String tokenUri, TicketMetadata metadata, String contractAddress, String ownedBy) {
         this.id = id;
         this.price = price;
         this.artistName = artistName;
@@ -36,7 +36,7 @@ public class TicketResponse {
         this.onSale = onSale;
         this.tokenId = tokenId;
         this.tokenUri = tokenUri;
-        this.metadata = metadata;
+        this.metadata = TicketMetadataResponse.of(metadata);
         this.contractAddress = contractAddress;
         this.ownedBy = ownedBy;
     }

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.event.ui;
 
 import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.service.EventService;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
@@ -18,6 +19,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
@@ -83,6 +85,18 @@ class EventControllerTest {
         SalesOption.FLAT_PRICE
     );
 
+    private static final TicketMetadata SAMPLE_TICKET_METADATA = TicketMetadata.builder()
+        .name("메타데이터")
+        .description("메타데이터 at Connectable")
+        .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test2.png")
+        .attributes(new HashMap<>(){{
+            put("Background", "Yellow");
+            put("Artist", "Joel");
+            put("Seat", "A5");
+        }})
+        .build();
+
+
     private static final TicketResponse TICKET_RESPONSE_1 = new TicketResponse(
         TICKET_ID_1,
         10000,
@@ -92,7 +106,7 @@ class EventControllerTest {
         true,
         0,
         "https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json",
-        null,
+        SAMPLE_TICKET_METADATA,
         "0x123456",
         "0xabcd"
     );
@@ -101,12 +115,12 @@ class EventControllerTest {
         TICKET_ID_2,
         10000,
         "빅나티",
-        1672412400000L,
+        LocalDateTime.of(2022, 8, 1, 18, 0),
         "이씨 콘서트 at Connectable",
         true,
         1,
         "https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json",
-        null,
+        SAMPLE_TICKET_METADATA,
         "0x123456",
         "0xabcd"
     );
@@ -128,7 +142,7 @@ class EventControllerTest {
 
         // expected
         mockMvc.perform(get("/events")
-            .contentType(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0]").exists())
             .andExpect(jsonPath("$[1]").exists())
@@ -148,7 +162,7 @@ class EventControllerTest {
 
         // expected
         mockMvc.perform(get("/events/{event-id}", EVENT_ID_1)
-            .contentType(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.artistName").value("빅나티"))
             .andDo(print());
@@ -163,7 +177,7 @@ class EventControllerTest {
 
         // expected
         mockMvc.perform(get("/events/{event-id}/tickets", EVENT_ID_1)
-            .contentType(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].id").value(1L))
             .andExpect(jsonPath("$[0].tokenUri")


### PR DESCRIPTION
## 작업 내용
- domain을 보호하기 위해 티켓 메타데이터에 dto를 도입합니다.

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
