### PR TITLE
refactor: service 레이어 Mapper 사용하여 DTO 변환 및 컨트롤러 ResponseEntity 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
         queryDslVersion = "5.0.0"
+        mapStructVersion = "1.4.2.Final"
     }
 }
 
@@ -63,6 +64,15 @@ dependencies {
     // Lombok
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
+
+    /**
+     * MapStruct
+     *
+     * annotationProcessor 이슈로 Mapstructure는 Lombok보다 하위에 있어야함.
+     * https://mapstruct.org/faq/#Can-I-use-MapStruct-together-with-Project-Lombok
+     */
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapStructVersion}"
+    implementation "org.mapstruct:mapstruct:${mapStructVersion}"
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -29,7 +29,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
 
     @Override
     public Optional<EventDetail> findEventDetailByEventId(Long eventId) {
-        return Optional.ofNullable(queryFactory.select(Projections.bean(
+        EventDetail result = queryFactory.select(Projections.bean(
             EventDetail.class,
             event.id,
             event.eventName,
@@ -58,13 +58,14 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .where(ticket.event.id.eq(eventId))
             .groupBy(event.id)
             .limit(1)
-            .fetchOne()
-        );
+            .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
     @Override
     public List<EventTicket> findAllTickets(Long eventId) {
-        return queryFactory.select(new QEventTicket(
+        List<EventTicket> result = queryFactory.select(new QEventTicket(
             ticket.id,
             ticket.price,
             artist.artistName,
@@ -82,11 +83,13 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .where(ticket.event.id.eq(eventId))
             .groupBy(ticket.id)
             .fetch();
+
+        return result;
     }
 
     @Override
     public Optional<EventTicket> findTicketByEventIdAndTicketId(Long eventId, Long ticketId) {
-        return Optional.ofNullable(queryFactory.select(new QEventTicket(
+        EventTicket result = queryFactory.select(new QEventTicket(
             ticket.id,
             ticket.price,
             artist.artistName,
@@ -103,7 +106,8 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .innerJoin(artist).on(event.artist.id.eq(artist.id))
             .where(ticket.event.id.eq(eventId)
                 .and(ticket.id.eq(ticketId)))
-            .fetchOne()
-        );
+            .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/backend/connectable/event/mapper/EventMapper.java
+++ b/src/main/java/com/backend/connectable/event/mapper/EventMapper.java
@@ -1,0 +1,28 @@
+package com.backend.connectable.event.mapper;
+
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.dto.EventDetail;
+import com.backend.connectable.event.domain.dto.EventTicket;
+import com.backend.connectable.event.ui.dto.EventDetailResponse;
+import com.backend.connectable.event.ui.dto.EventResponse;
+import com.backend.connectable.event.ui.dto.TicketResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface EventMapper {
+
+    EventMapper INSTANCE = Mappers.getMapper(EventMapper.class);
+
+    @Mapping(target="name", source = "eventName")
+    @Mapping(target="image", source = "eventImage")
+    EventDetailResponse eventDetailToResponse(EventDetail eventDetail);
+
+    @Mapping(target="name", source = "eventName")
+    @Mapping(target="image", source = "eventImage")
+    @Mapping(target="date", source = "startTime")
+    EventResponse eventToResponse(Event event);
+
+    TicketResponse ticketToResponse(EventTicket eventTicket);
+}

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -1,8 +1,10 @@
 package com.backend.connectable.event.service;
 
+import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.dto.EventDetail;
 import com.backend.connectable.event.domain.dto.EventTicket;
 import com.backend.connectable.event.domain.repository.EventRepository;
+import com.backend.connectable.event.mapper.EventMapper;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.backend.connectable.event.ui.dto.TicketResponse;
@@ -25,60 +27,22 @@ public class EventService {
     private final EventRepository eventRepository;
 
     public List<EventResponse> getList() {
-        return eventRepository.findAll().stream()
-            .map(event -> EventResponse.builder()
-                .id(event.getId())
-                .name(event.getEventName())
-                .image(event.getEventImage())
-                .date(event.getStartTime())
-                .description(event.getDescription())
-                .salesFrom(event.getSalesFrom())
-                .salesTo(event.getSalesTo())
-                .build())
+        List<Event> events = eventRepository.findAll();
+        return events.stream()
+            .map(EventMapper.INSTANCE::eventToResponse)
             .collect(Collectors.toList());
     }
 
     public EventDetailResponse getEventDetail(Long eventId) {
         EventDetail eventDetail = eventRepository.findEventDetailByEventId(eventId)
             .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.EVENT_NOT_EXISTS));
-        return EventDetailResponse.builder()
-            .id(eventDetail.getId())
-            .name(eventDetail.getEventName())
-            .image(eventDetail.getEventImage())
-            .artistName(eventDetail.getArtistName())
-            .artistImage(eventDetail.getArtistImage())
-            .date(eventDetail.getEndTime())
-            .description(eventDetail.getDescription())
-            .salesFrom(eventDetail.getSalesFrom())
-            .salesTo(eventDetail.getSalesTo())
-            .twitterUrl(eventDetail.getTwitterUrl())
-            .instagramUrl(eventDetail.getInstagramUrl())
-            .webpageUrl(eventDetail.getWebpageUrl())
-            .totalTicketCount(eventDetail.getTotalTicketCount())
-            .onSaleTicketCount(eventDetail.getOnSaleTicketCount())
-            .startTime(eventDetail.getStartTime())
-            .endTime(eventDetail.getEndTime())
-            .price(eventDetail.getPrice())
-            .location(eventDetail.getLocation())
-            .eventSalesOption(eventDetail.getEventSalesOption())
-            .build();
+        return EventMapper.INSTANCE.eventDetailToResponse(eventDetail);
     }
 
     public List<TicketResponse> getTicketList(Long eventId) {
         List<EventTicket> eventTickets = eventRepository.findAllTickets(eventId);
         return eventTickets.stream()
-            .map(ticket -> TicketResponse.builder()
-                .id(ticket.getId())
-                .price(ticket.getPrice())
-                .artistName(ticket.getArtistName())
-                .eventDate(ticket.getEventDate())
-                .eventName(ticket.getEventName())
-                .ticketSalesStatus(ticket.getTicketSalesStatus())
-                .tokenId(ticket.getTokenId())
-                .tokenUri(ticket.getTokenUri())
-                .metadata(ticket.getMetadata())
-                .contractAddress(ticket.getContractAddress())
-                .build())
+            .map(EventMapper.INSTANCE::ticketToResponse)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/backend/connectable/event/ui/EventController.java
+++ b/src/main/java/com/backend/connectable/event/ui/EventController.java
@@ -21,8 +21,9 @@ public class EventController {
     private final EventService eventService;
 
     @GetMapping
-    public List<EventResponse> getList() {
-        return eventService.getList();
+    public ResponseEntity<List<EventResponse>> getList() {
+        List<EventResponse> eventResponses = eventService.getList();
+        return ResponseEntity.ok(eventResponses);
     }
 
     @GetMapping("/{id}")
@@ -32,14 +33,14 @@ public class EventController {
     }
 
     @GetMapping("/{id}/tickets")
-    public List<TicketResponse> getTicketList(@PathVariable("id") Long eventId) {
-        List<TicketResponse> ticketResponse = eventService.getTicketList(eventId);
-        return ticketResponse;
+    public ResponseEntity<List<TicketResponse>> getTicketList(@PathVariable("id") Long eventId) {
+        List<TicketResponse> ticketResponses = eventService.getTicketList(eventId);
+        return ResponseEntity.ok(ticketResponses);
     }
 
     @GetMapping("/{event-id}/tickets/{ticket-id}")
-    public TicketResponse getTicketInfo(@PathVariable("event-id") Long eventId, @PathVariable("ticket-id") Long ticketId) {
+    public ResponseEntity<TicketResponse> getTicketInfo(@PathVariable("event-id") Long eventId, @PathVariable("ticket-id") Long ticketId) {
         TicketResponse ticketResponse = eventService.getTicketInfo(eventId, ticketId);
-        return ticketResponse;
+        return ResponseEntity.ok(ticketResponse);
     }
 }

--- a/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
@@ -19,7 +19,6 @@ public class EventDetailResponse {
     private String image;
     private String artistName;
     private String artistImage;
-    private Long date;
     private String description;
     private Long salesFrom;
     private Long salesTo;
@@ -35,13 +34,12 @@ public class EventDetailResponse {
     private EventSalesOption eventSalesOption;
 
     @Builder
-    public EventDetailResponse(Long id, String name, String image, String artistName, String artistImage, LocalDateTime date, String description, LocalDateTime salesFrom, LocalDateTime salesTo, String twitterUrl, String instagramUrl, String webpageUrl, int totalTicketCount, int onSaleTicketCount, LocalDateTime startTime, LocalDateTime endTime, int price, String location, EventSalesOption eventSalesOption) {
+    public EventDetailResponse(Long id, String name, String image, String artistName, String artistImage, String description, LocalDateTime salesFrom, LocalDateTime salesTo, String twitterUrl, String instagramUrl, String webpageUrl, int totalTicketCount, int onSaleTicketCount, LocalDateTime startTime, LocalDateTime endTime, int price, String location, EventSalesOption eventSalesOption) {
         this.id = id;
         this.name = name;
         this.image = image;
         this.artistName = artistName;
         this.artistImage = artistImage;
-        this.date = DateTimeUtil.toEpochMilliSeconds(date);
         this.description = description;
         this.salesFrom = DateTimeUtil.toEpochMilliSeconds(salesFrom);
         this.salesTo = DateTimeUtil.toEpochMilliSeconds(salesTo);

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -70,7 +70,6 @@ class EventControllerTest {
         "https://connectable-events.s3.ap-northeast-2.amazonaws.com/image_0xtest.jpeg",
         "빅나티",
         "https://user-images.githubusercontent.com/54073761/179218800-dda72067-3b25-4ca3-b53b-4895c5e49213.jpeg",
-        LocalDateTime.of(2022, 7, 12, 0, 0),
         "이씨 콘서트 at Connectable",
         LocalDateTime.of(2022, 7, 12, 0, 0),
         LocalDateTime.of(2022, 7, 30, 0, 0),


### PR DESCRIPTION
## 작업 내용
- service 레이어 내 DTO 주입하는 부분 Mapper 로 변경 ( [참고 링크](https://www.baeldung.com/mapstruct) )
ㄴ변경 사유 
  1. 많은 수의 필드를 빌더 패턴으로 주입하여 가독성 저해
  2.  필드 네이밍 오기입 확률 떨어짐 
  3. 컴파일 통과시, Mapper 구현체를 통해 디버깅 가능
- 규격화를 위해 응답 컨트롤러 ResponseEntity Wrapping

## 주의 사항
- lombok 하위에 mapstruct 의존성 위치해야 함. 
- date 필드 startTime과 동일하여 제거
- 테스트 코드 강화 필요

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
