### PR TITLE
feat: 주문 등록 기능 API 추가

### DIFF
--- a/src/main/java/com/backend/connectable/ConnectableApplication.java
+++ b/src/main/java/com/backend/connectable/ConnectableApplication.java
@@ -2,7 +2,9 @@ package com.backend.connectable;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ConnectableApplication {
 

--- a/src/main/java/com/backend/connectable/global/entity/BaseEntity.java
+++ b/src/main/java/com/backend/connectable/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.backend.connectable.global.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedDate;
+}
+

--- a/src/main/java/com/backend/connectable/order/domain/Order.java
+++ b/src/main/java/com/backend/connectable/order/domain/Order.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -14,6 +16,7 @@ public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
     private Long id;
 
     @ManyToOne
@@ -26,12 +29,25 @@ public class Order extends BaseEntity {
 
     private String ordererPhoneNumber;
 
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name="order_id")
+    private List<OrderDetail> orderDetails = new ArrayList<>();
+
     @Builder
-    public Order(Long id, User user, int amount, String ordererName, String ordererPhoneNumber) {
+    public Order(Long id, User user, int amount, String ordererName, String ordererPhoneNumber, List<OrderDetail> orderDetails) {
         this.id = id;
         this.user = user;
         this.amount = amount;
         this.ordererName = ordererName;
         this.ordererPhoneNumber = ordererPhoneNumber;
+        this.orderDetails.addAll(orderDetails);
+    }
+
+    public Order(User user, int amount, String ordererName, String ordererPhoneNumber, List<OrderDetail> orderDetails) {
+        this.user = user;
+        this.amount = amount;
+        this.ordererName = ordererName;
+        this.ordererPhoneNumber = ordererPhoneNumber;
+        this.orderDetails.addAll(orderDetails);
     }
 }

--- a/src/main/java/com/backend/connectable/order/domain/Order.java
+++ b/src/main/java/com/backend/connectable/order/domain/Order.java
@@ -1,17 +1,16 @@
 package com.backend.connectable.order.domain;
 
+import com.backend.connectable.global.entity.BaseEntity;
 import com.backend.connectable.user.domain.User;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "ORDERS")
-public class Order {
+@Table(name = "orders")
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,9 +25,6 @@ public class Order {
     private String ordererName;
 
     private String ordererPhoneNumber;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Builder
     public Order(Long id, User user, int amount, String ordererName, String ordererPhoneNumber) {

--- a/src/main/java/com/backend/connectable/order/domain/Order.java
+++ b/src/main/java/com/backend/connectable/order/domain/Order.java
@@ -1,0 +1,41 @@
+package com.backend.connectable.order.domain;
+
+import com.backend.connectable.user.domain.User;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "ORDERS")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private User user;
+
+    private int amount;
+
+    private String ordererName;
+
+    private String ordererPhoneNumber;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Order(Long id, User user, int amount, String ordererName, String ordererPhoneNumber) {
+        this.id = id;
+        this.user = user;
+        this.amount = amount;
+        this.ordererName = ordererName;
+        this.ordererPhoneNumber = ordererPhoneNumber;
+    }
+}

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -1,0 +1,44 @@
+package com.backend.connectable.order.domain;
+
+import com.backend.connectable.event.domain.Ticket;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+
+@Entity
+@NoArgsConstructor
+public class OrderDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(nullable = false)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+    private String txHash;
+
+    @OneToOne
+    private Ticket ticket;
+
+    @Builder
+    public OrderDetail(Long id, Order order, OrderStatus orderStatus, LocalDateTime modifiedDate, String txHash, Ticket ticket) {
+        this.id = id;
+        this.order = order;
+        this.orderStatus = orderStatus;
+        this.modifiedDate = modifiedDate;
+        this.txHash = txHash;
+        this.ticket = ticket;
+    }
+}

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -1,17 +1,15 @@
 package com.backend.connectable.order.domain;
 
 import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.global.entity.BaseEntity;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
-
 
 @Entity
 @NoArgsConstructor
-public class OrderDetail {
+public class OrderDetail extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,20 +22,17 @@ public class OrderDetail {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
-    @LastModifiedDate
-    private LocalDateTime modifiedDate;
-
+    @Column(nullable = true)
     private String txHash;
 
     @OneToOne
     private Ticket ticket;
 
     @Builder
-    public OrderDetail(Long id, Order order, OrderStatus orderStatus, LocalDateTime modifiedDate, String txHash, Ticket ticket) {
+    public OrderDetail(Long id, Order order, OrderStatus orderStatus, String txHash, Ticket ticket) {
         this.id = id;
         this.order = order;
         this.orderStatus = orderStatus;
-        this.modifiedDate = modifiedDate;
         this.txHash = txHash;
         this.ticket = ticket;
     }

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -15,10 +15,6 @@ public class OrderDetail extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL)
-    @JoinColumn(nullable = false)
-    private Order order;
-
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
@@ -29,11 +25,14 @@ public class OrderDetail extends BaseEntity {
     private Ticket ticket;
 
     @Builder
-    public OrderDetail(Long id, Order order, OrderStatus orderStatus, String txHash, Ticket ticket) {
+    public OrderDetail(Long id, OrderStatus orderStatus, String txHash, Ticket ticket) {
         this.id = id;
-        this.order = order;
         this.orderStatus = orderStatus;
         this.txHash = txHash;
         this.ticket = ticket;
+    }
+
+    public OrderDetail(OrderStatus orderStatus, String txHash, Ticket ticket) {
+        this(null, orderStatus, txHash, ticket);
     }
 }

--- a/src/main/java/com/backend/connectable/order/domain/OrderStatus.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.backend.connectable.order.domain;
+
+public enum OrderStatus {
+
+    REQUESTED, PAID, UNPAID, TRANSFER_SUCCESS, TRANSFER_FAIL
+}

--- a/src/main/java/com/backend/connectable/order/domain/repository/OrderDetailRepository.java
+++ b/src/main/java/com/backend/connectable/order/domain/repository/OrderDetailRepository.java
@@ -1,7 +1,0 @@
-package com.backend.connectable.order.domain.repository;
-
-import com.backend.connectable.order.domain.OrderDetail;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
-}

--- a/src/main/java/com/backend/connectable/order/domain/repository/OrderDetailRepository.java
+++ b/src/main/java/com/backend/connectable/order/domain/repository/OrderDetailRepository.java
@@ -1,0 +1,7 @@
+package com.backend.connectable.order.domain.repository;
+
+import com.backend.connectable.order.domain.OrderDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
+}

--- a/src/main/java/com/backend/connectable/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/backend/connectable/order/domain/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.backend.connectable.order.domain.repository;
+
+import com.backend.connectable.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/backend/connectable/order/service/OrderService.java
+++ b/src/main/java/com/backend/connectable/order/service/OrderService.java
@@ -1,0 +1,54 @@
+package com.backend.connectable.order.service;
+
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.order.domain.Order;
+import com.backend.connectable.order.domain.OrderDetail;
+import com.backend.connectable.order.domain.OrderStatus;
+import com.backend.connectable.order.domain.repository.OrderDetailRepository;
+import com.backend.connectable.order.ui.dto.OrderRequest;
+import com.backend.connectable.order.ui.dto.OrderResponse;
+import com.backend.connectable.security.ConnectableUserDetails;
+import com.backend.connectable.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class OrderService {
+
+    private final OrderDetailRepository orderDetailRepository;
+    private final TicketRepository ticketRepository;
+
+    @Transactional
+    public OrderResponse registOrder(ConnectableUserDetails userDetails, OrderRequest request) {
+        User user = userDetails.getUser();
+
+        Order order = Order.builder()
+            .user(user)
+            .amount(request.getAmount())
+            .ordererName(request.getUserName())
+            .ordererPhoneNumber(request.getPhoneNumber())
+            .build();
+
+        List<Ticket> tickets = ticketRepository.findAllById(request.getTicketIds());
+        List<OrderDetail> orderDetails = request.getTicketIds().stream()
+            .map(ticketId -> OrderDetail.builder()
+                .order(order)
+                .orderStatus(OrderStatus.REQUESTED)
+                .txHash(null)
+                .ticket(tickets.remove(0))
+                .build())
+                .collect(Collectors.toList());
+
+        orderDetailRepository.saveAll(orderDetails);
+        return OrderResponse.from("true");
+    }
+}

--- a/src/main/java/com/backend/connectable/order/ui/OrderController.java
+++ b/src/main/java/com/backend/connectable/order/ui/OrderController.java
@@ -1,0 +1,32 @@
+package com.backend.connectable.order.ui;
+
+import com.backend.connectable.exception.sequence.ValidationSequence;
+import com.backend.connectable.order.service.OrderService;
+import com.backend.connectable.order.ui.dto.OrderRequest;
+import com.backend.connectable.order.ui.dto.OrderResponse;
+import com.backend.connectable.security.ConnectableUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<OrderResponse> registOrder(
+        @AuthenticationPrincipal ConnectableUserDetails userDetails,
+        @RequestBody @Validated(ValidationSequence.class) OrderRequest request
+    ) {
+        OrderResponse orderResponse = orderService.registOrder(userDetails, request);
+        return ResponseEntity.ok(orderResponse);
+    }
+}

--- a/src/main/java/com/backend/connectable/order/ui/dto/OrderRequest.java
+++ b/src/main/java/com/backend/connectable/order/ui/dto/OrderRequest.java
@@ -30,4 +30,11 @@ public class OrderRequest {
     private List<Long> ticketIds;
 
     private int amount;
+
+    public OrderRequest(String userName, String phoneNumber, List<Long> ticketIds, int amount) {
+        this.userName = userName;
+        this.phoneNumber = phoneNumber;
+        this.ticketIds = ticketIds;
+        this.amount = amount;
+    }
 }

--- a/src/main/java/com/backend/connectable/order/ui/dto/OrderRequest.java
+++ b/src/main/java/com/backend/connectable/order/ui/dto/OrderRequest.java
@@ -1,0 +1,33 @@
+package com.backend.connectable.order.ui.dto;
+
+import com.backend.connectable.exception.sequence.ValidationGroups;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderRequest {
+
+    @NotBlank(message = "입금자 확인을 위해 주문자명은 필수 입력값 입니다.")
+    @Pattern(regexp = "^[가-힣]{2,4}$",
+        message = "주문자명은 2자 이상 4자 이하 한글로 구성된 이름이어야 합니다.",
+        groups = ValidationGroups.PatternCheckGroup.class)
+    private String userName;
+
+    @NotBlank(message = "입금자 확인을 위해 연락처는 필수 입력값 입니다.",
+        groups = ValidationGroups.NotEmptyGroup.class)
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+        message = "연락처는 xxx-xxxx-xxxx 양식으로 구성되어야 합니다.",
+        groups = ValidationGroups.PatternCheckGroup.class)
+    private String phoneNumber;
+
+    private List<Long> ticketIds;
+
+    private int amount;
+}

--- a/src/main/java/com/backend/connectable/order/ui/dto/OrderResponse.java
+++ b/src/main/java/com/backend/connectable/order/ui/dto/OrderResponse.java
@@ -1,0 +1,21 @@
+package com.backend.connectable.order.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class OrderResponse {
+
+    private String status;
+
+    public static OrderResponse from(String status) {
+        return new OrderResponse(
+            "true"
+        );
+    }
+}

--- a/src/main/java/com/backend/connectable/security/SecurityConfiguration.java
+++ b/src/main/java/com/backend/connectable/security/SecurityConfiguration.java
@@ -25,7 +25,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .authorizeRequests()
                         .antMatchers(HttpMethod.OPTIONS, "/**/*").permitAll()
                         .antMatchers("/users/login", "/events", "/events/**").permitAll()
-                        .antMatchers("/users", "/users/tickets").authenticated()
+                        .antMatchers("/users", "/users/tickets", "/orders").authenticated()
                         .anyRequest().permitAll()
                 .and()
                     .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -35,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfiguration.class, JwtAuthenticationFilter.class})
     })
+@MockBean(JpaMetamodelMappingContext.class)
 class EventControllerTest {
 
     private static final Long EVENT_ID_1 = 1L;

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -1,0 +1,160 @@
+package com.backend.connectable.order.service;
+
+import com.backend.connectable.artist.domain.Artist;
+import com.backend.connectable.artist.domain.repository.ArtistRepository;
+import com.backend.connectable.event.domain.*;
+import com.backend.connectable.event.domain.repository.EventRepository;
+import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.order.ui.dto.OrderRequest;
+import com.backend.connectable.order.ui.dto.OrderResponse;
+import com.backend.connectable.security.ConnectableUserDetails;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class OrderServiceTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ArtistRepository artistRepository;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    TicketRepository ticketRepository;
+
+    @Autowired
+    OrderService orderService;
+
+    private User user;
+    private Artist artist;
+    private Event event;
+    private TicketMetadata ticket1Metadata;
+    private Ticket ticket1;
+    private TicketMetadata ticket2Metadata;
+    private Ticket ticket2;
+
+    private final String userKlaytnAddress = "0x12345678";
+    private final String userNickname = "leejp";
+    private final String userPhoneNumber = "010-3333-7777";
+    private final boolean userPrivacyAgreement = true;
+    private final boolean userIsActive = true;
+
+    @BeforeEach
+    void setUp() {
+        ticketRepository.deleteAll();
+        eventRepository.deleteAll();
+        artistRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user = User.builder()
+            .klaytnAddress(userKlaytnAddress)
+            .nickname(userNickname)
+            .phoneNumber(userPhoneNumber)
+            .privacyAgreement(userPrivacyAgreement)
+            .isActive(userIsActive)
+            .build();
+
+        artist = Artist.builder()
+            .bankCompany("NH")
+            .bankAccount("9000000000099")
+            .artistName("빅나티")
+            .email("bignaughty@gmail.com")
+            .password("temptemp1234")
+            .phoneNumber("01012345678")
+            .artistImage("https://image.url")
+            .build();
+
+        event = Event.builder()
+            .description("조엘의 콘서트 at Connectable")
+            .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+            .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+            .contractAddress("0x123456")
+            .eventName("조엘의 콘서트")
+            .eventImage("https://image.url")
+            .twitterUrl("https://github.com/joelonsw")
+            .instagramUrl("https://www.instagram.com/jyoung_with/")
+            .webpageUrl("https://papimon.tistory.com/")
+            .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+            .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+            .eventSalesOption(EventSalesOption.FLAT_PRICE)
+            .artist(artist)
+            .build();
+
+        ticket1Metadata = TicketMetadata.builder()
+            .name("조엘 콘서트 #1")
+            .description("조엘의 콘서트 at Connectable")
+            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test1.png")
+            .attributes(new HashMap<>(){{
+                put("Background", "Yellow");
+                put("Artist", "Joel");
+                put("Seat", "A6");
+            }})
+            .build();
+
+        ticket1 = Ticket.builder()
+            .user(user)
+            .event(event)
+            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
+            .price(100000)
+            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+            .ticketMetadata(ticket1Metadata)
+            .build();
+
+        ticket2Metadata = TicketMetadata.builder()
+            .name("조엘 콘서트 #2")
+            .description("조엘의 콘서트 at Connectable")
+            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test2.png")
+            .attributes(new HashMap<>(){{
+                put("Background", "Yellow");
+                put("Artist", "Joel");
+                put("Seat", "A5");
+            }})
+            .build();
+
+        ticket2 = Ticket.builder()
+            .user(user)
+            .event(event)
+            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
+            .price(100000)
+            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
+            .ticketMetadata(ticket2Metadata)
+            .build();
+
+        userRepository.save(user);
+        artistRepository.save(artist);
+        eventRepository.save(event);
+        ticketRepository.saveAll(Arrays.asList(ticket1, ticket2));
+    }
+
+    @DisplayName("티켓을 구매하였을때, 주문정보 및 주문상세정보가 등록된다.")
+    @Test
+    void registOrder() {
+        // given
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user);
+        OrderRequest orderRequest = new OrderRequest("이정필", "010-3333-7777", Arrays.asList(1L, 2L), 30000);
+
+        // when
+        OrderResponse orderResponse = orderService.registOrder(connectableUserDetails, orderRequest);
+
+        // then
+        Assertions.assertThat(orderResponse.getStatus()).isEqualTo("true");
+    }
+}

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;


### PR DESCRIPTION
## 작업 내용
- 주문등록시 주문 및 주문상세 정보 등록 API 추가
ㄴ 주문 서비스 레이어쪽이 OrderDetail과 Order를 들고 있는데, 이를 분리할 방법에 대해 고안이 필요합니다. 
[링크](https://techblog.woowahan.com/2668/) 에서 Embed를 활용하는 방법은 원테이블이 될 것 같아, 우선 엔티티 분리되는 방향으로 작성하였습니다. Best-practice가 있다면 공유해주시면 감사하겠습니다. 
- SecurityConfiguration에 orders 엔드포인트 추가


## 주의 사항
- WebMVCTest시 JPA Bean 을 등록하지 않아 @MockBean(JpaMetamodelMappingContext.class) 추가
- 예약어 이슈로 Order 엔티티 orders로 테이블 명명
- 트랜잭션 방법 정한 뒤, OrderService Layer 예외처리 필요
- Slack appender는 별도 브랜치 작성 예정

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
