### PR TITLE
fix: ticketSalesStatus null 로 내려오는 현상 수정

### DIFF
--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -56,6 +56,7 @@ public class EventService {
             .artistName(eventTicket.getArtistName())
             .eventDate(eventTicket.getEventDate())
             .eventName(eventTicket.getEventName())
+            .ticketSalesStatus(eventTicket.getTicketSalesStatus())
             .tokenId(eventTicket.getTokenId())
             .tokenUri(eventTicket.getTokenUri())
             .metadata(eventTicket.getMetadata())


### PR DESCRIPTION
## 작업 내용
- GET /events/{event-id}/tickets/{ticket-id} 조회 시 ticketSalesStatus Null 로 내려오는 현상 수정

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
