### PR TITLE
refactor: TicketMetadata hashcode/equals 정의

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadata.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadata.java
@@ -1,9 +1,6 @@
 package com.backend.connectable.event.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 import java.util.Map;
@@ -12,6 +9,7 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class TicketMetadata {
     private String name;
     private String description;

--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadataAttribute.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadataAttribute.java
@@ -1,14 +1,12 @@
 package com.backend.connectable.event.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class TicketMetadataAttribute {
     private String trait_type;
     private String value;


### PR DESCRIPTION
## 작업 내용
1. **TicketMetadata 필드에 대해 hibernate가 dirty check를 제대로 하지 못하는 문제를 발견하여, 해당 도메인 필드에 대해서 hashcode/equals를 재정의하였습니다.**
    - 참고자료: https://jojoldu.tistory.com/536
    - hibernate 내부 구현상, 필드를 하나하나 비교하며 동등성을 따져 dirty check를 진행하는데, 동등성 비교가 불가능한 (equals/hashcode가 오버라이딩 되지 않은) 필드에 대해서는 객체 레퍼런스를 통해 비교한다고 하네요. 이 부분을 수정하였습니다. 
    - equals/hashcode 오버라이딩은 `@EqualsAndHashCode` 롬복을 통해 비교합니다. 
        -  By default, it'll use all non-static, non-transient fields, but you can modify which fields are used 라고 하네요. 
        - 각 필드들이 같다면 확보되면 동등/동일한 것으로 간주하도록 재정의하도록 구성됩니다. 
            - 참고자료: https://projectlombok.org/features/EqualsAndHashCode

## 주의 사항
- 나중에 엔티티들에 대해 hashcode/equals를 어떻게 가져갈지 같이 논의해봅시다 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
