### PR TITLE
fix: KLIP 주소를 소문자로 통일

### DIFF
--- a/src/main/java/com/backend/connectable/klip/service/KlipService.java
+++ b/src/main/java/com/backend/connectable/klip/service/KlipService.java
@@ -22,7 +22,8 @@ public class KlipService {
                 return KlipAuthLoginResponse.ofPrepared();
             }
             String klaytnAddress = klipAuthHandleResponse.getResult()
-                    .getKlaytn_address();
+                    .getKlaytn_address()
+                    .toLowerCase();
             return KlipAuthLoginResponse.ofCompleted(klaytnAddress);
         } catch (RestClientException | NullPointerException e) {
             return KlipAuthLoginResponse.ofFailed();

--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -32,7 +32,7 @@ public class User {
     @Builder
     public User(Long id, String klaytnAddress, String nickname, String phoneNumber, boolean privacyAgreement, boolean isActive) {
         this.id = id;
-        this.klaytnAddress = klaytnAddress;
+        this.klaytnAddress = klaytnAddress.toLowerCase();
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.privacyAgreement = privacyAgreement;


### PR DESCRIPTION
## 작업 내용
- KLIP 에서 받아와 유저에 저장할때 소문자로 통일하도록 변경합니다!

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
