### PR TITLE
feat: admin 토큰 검증 로직 구현

### DIFF
--- a/src/main/java/com/backend/connectable/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/connectable/security/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -22,11 +23,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = AuthorizationExtractor.extract(request);
+        String path = request.getRequestURI();
         if (!Objects.isNull(token)) {
-            jwtProvider.verify(token);
-            Authentication authentication = jwtProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            verifyTokenAccordingToPath(token, path);
         }
         filterChain.doFilter(request, response);
+    }
+
+    private void verifyTokenAccordingToPath(String token, String path) {
+        if (path.startsWith("/admin")) {
+            jwtProvider.verifyAdmin(token);
+            return;
+        }
+        jwtProvider.verify(token);
+        Authentication authentication = jwtProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/src/main/java/com/backend/connectable/security/JwtProvider.java
+++ b/src/main/java/com/backend/connectable/security/JwtProvider.java
@@ -25,6 +25,9 @@ public class JwtProvider {
     @Value("${jwt.expire-time}")
     private Long duration;
 
+    @Value("${jwt.admin-payload}")
+    private String adminPayload;
+
     private Algorithm algorithm;
 
     private final UserDetailsService userDetailsService;
@@ -63,5 +66,12 @@ public class JwtProvider {
     public Authentication getAuthentication(String token) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(exportClaim(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public void verifyAdmin(String token) {
+        String adminPayload = exportClaim(token);
+        if (!this.adminPayload.equals(adminPayload)) {
+            throw new IllegalArgumentException("어드민 토큰이 아닙니다.");
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
 jwt:
    secret: uacc-to-the-moon
    expire-time: 14400000
+   admin-payload: admin-payload
 logging:
   level:
     org:
@@ -68,6 +69,7 @@ aws:
 jwt:
   secret: uacc-to-the-moon
   expire-time: 14400000
+  admin-payload: ${jwt.admin_payload}
 logging:
   level:
     org:

--- a/src/test/java/com/backend/connectable/security/JwtProviderTest.java
+++ b/src/test/java/com/backend/connectable/security/JwtProviderTest.java
@@ -3,6 +3,7 @@ package com.backend.connectable.security;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
@@ -12,6 +13,9 @@ class JwtProviderTest {
 
     @Autowired
     JwtProvider jwtProvider;
+
+    @Value("${jwt.admin-payload}")
+    private String adminPayload;
 
     @Test
     @DisplayName("JwtProvider를 이용하여, jwt 토큰을 발행한다.")
@@ -72,6 +76,28 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.exportClaim(invalidToken))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("어드민 JWT 토큰에 대해 verify 할 수 있다.")
+    @Test
+    void verifyAdminToken() {
+        // given
+        String adminToken = jwtProvider.generateToken(adminPayload);
+
+        // when & then
+        assertThatCode(() -> jwtProvider.verifyAdmin(adminToken))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("어드민 JWT 토큰이 아닌 대해 verify시 에러가 발생한다.")
+    @Test
+    void verifyAdminTokenThrowsException() {
+        // given
+        String adminToken = jwtProvider.generateToken("weird-payload");
+
+        // when & then
+        assertThatThrownBy(() -> jwtProvider.verifyAdmin(adminToken))
             .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## 작업 내용
1. **JwtProvider 에서 어드민 토큰에 대해 토큰 검증 기능을 추가했습니다**
  - admin 토큰에 대해 payload가 같아야만 통과 가능하도록 구현했습니다.
  - 이렇게 되면 payload가 민감정보가 되니 파라미터 스토어에 등록해 두었습니다. 
  - jwt secret도 민감정보이니, prod 배포전에 파라미터 스토어로 이전하지요!
    - 민감정보 분류도 기술 부채인듯합니다 :)

2. **어드민 토큰을 검증할 수 있도록 Filter에 로직을 추가했습니다**
  - 원래 계획은 Interceptor를 통해서 검증할려했으나, 검증 로직을 Security에 몰아두는 것이 더 나은 방법이라고 판단하여 다음과 같이 작성하였습니다. 
  - Interceptor를 통한 인증/인가 방식은 어드민 레포에서 확인 가능합니다. 
    - https://github.com/Team-UACC/connectable-admin/tree/master/src/main/java/fans/connectable/admin/auth
  - 우선은 /admin 요청에 대해서 verifyAdmin() 함수를 호출하여 검사하는 방식을 채택했습니다만,,, 최선의 방법인지는 모르겠네요. 피드백해주시면 감사하겠습니다! (시큐리티 어려워!)

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
