### PR TITLE
fix: 티켓 전송 엔티티 반영 로직 추가

### DIFF
--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -198,7 +198,7 @@ public class DataLoader implements ApplicationRunner {
             .build();
 
         Ticket joelTicket4 = Ticket.builder()
-            .user(admin)
+            .user(joel)
             .event(joelEvent)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/4.json")
             .tokenId(4)
@@ -378,7 +378,7 @@ public class DataLoader implements ApplicationRunner {
             .ordererPhoneNumber("010-1234-5678")
             .build();
 
-        OrderDetail orderDetail1 = new OrderDetail(OrderStatus.REQUESTED, null, joelTicket4);
+        OrderDetail orderDetail1 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x5a79e442c91f49bad73ed753625a72e2043d3806682f69f1fcdbdead98a50a2f", joelTicket4);
         OrderDetail orderDetail2 = new OrderDetail(OrderStatus.REQUESTED, null, joelTicket5);
         OrderDetail orderDetail3 = new OrderDetail(OrderStatus.REQUESTED, null, joelTicket6);
         List<OrderDetail> order1Details = Arrays.asList(orderDetail1, orderDetail2, orderDetail3);

--- a/src/main/java/com/backend/connectable/admin/service/AdminService.java
+++ b/src/main/java/com/backend/connectable/admin/service/AdminService.java
@@ -2,6 +2,7 @@ package com.backend.connectable.admin.service;
 
 import com.backend.connectable.exception.KasException;
 import com.backend.connectable.kas.service.KasService;
+import com.backend.connectable.kas.service.dto.TransactionResponse;
 import com.backend.connectable.order.domain.OrderDetail;
 import com.backend.connectable.order.domain.repository.OrderDetailRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,8 @@ public class AdminService {
         int tokenId = orderDetail.getTokenId();
         String receiverAddress = orderDetail.getKlaytnAddress();
         try {
-            kasService.sendMyToken(contractAddress, tokenId, receiverAddress);
-            orderDetail.transferSuccess();
+            TransactionResponse transactionResponse = kasService.sendMyToken(contractAddress, tokenId, receiverAddress);
+            orderDetail.transferSuccess(transactionResponse.getTransactionHash());
         } catch (KasException kasException) {
             orderDetail.transferFail();
         }

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -53,4 +53,8 @@ public class Ticket {
     public String getContractAddress() {
         return event.getContractAddress();
     }
+
+    public void transferredTo(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -62,8 +62,10 @@ public class OrderDetail extends BaseEntity {
         this.orderStatus = orderStatus.toRefund();
     }
 
-    public void transferSuccess() {
+    public void transferSuccess(String txHash) {
         this.orderStatus = orderStatus.toTransferSuccess();
+        this.txHash = txHash;
+        this.ticket.transferredTo(order.getUser());
     }
 
     public void transferFail() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,26 +3,26 @@ spring:
     active: local
 ---
 spring:
-   config:
-     activate:
-       on-profile: local
-   jpa:
-     hibernate:
-       ddl-auto: create
-     properties:
-       hibernate:
-         format_sql: true
-         dialect: org.hibernate.dialect.H2Dialect
-     show-sql: true
-   datasource:
-     driver-class-name: org.h2.Driver
-     url: jdbc:h2:mem:connectable
-     username: sa
-     password:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:connectable
+    username: sa
+    password:
 jwt:
-   secret: uacc-to-the-moon
-   expire-time: 14400000
-   admin-payload: admin-payload
+  secret: uacc-to-the-moon
+  expire-time: 14400000
+  admin-payload: admin-payload
 logging:
   level:
     org:
@@ -67,7 +67,7 @@ aws:
     profile-separator: _
     name: connectable
 jwt:
-  secret: uacc-to-the-moon
+  secret: ${jwt.secret}
   expire-time: 14400000
   admin-payload: ${jwt.admin_payload}
 logging:

--- a/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
@@ -166,7 +166,8 @@ class AdminServiceTest {
 
         orderRepository.save(order);
 
-        given(kasService.sendMyToken(any(), any(), any())).willReturn(new TransactionResponse());
+        given(kasService.sendMyToken(any(String.class), any(Integer.class), any(String.class)))
+            .willReturn(new TransactionResponse("Submitted", "0x1234abcd"));
     }
 
     @DisplayName("OrderDetail의 ID에 대해 Paid로 상태를 변경, 티켓을 전송할 수 있으며 Transfer Success로 변환이 가능하다.")
@@ -181,6 +182,8 @@ class AdminServiceTest {
         // then
         OrderDetail resultOrderDetail = orderDetailRepository.findById(orderDetailId).get();
         assertThat(resultOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.TRANSFER_SUCCESS);
+        assertThat(resultOrderDetail.getTxHash()).isEqualTo("0x1234abcd");
+        assertThat(resultOrderDetail.getTicket().getUser().getId()).isEqualTo(joel.getId());
     }
 
     @DisplayName("OrderDetail의 ID에 대해 Unpaid로 상태를 변경할 수 있다.")

--- a/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
+++ b/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
@@ -85,19 +85,6 @@ class OrderDetailTest {
             .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @DisplayName("OrderDetail의 orderStatus가 paid 경우 transferSuccess로 변경이 가능하다.")
-    @Test
-    void toTransferSuccess() {
-        // given
-        OrderDetail orderDetail = OrderDetail.builder()
-            .orderStatus(OrderStatus.PAID)
-            .build();
-
-        // when
-        assertThatCode(() -> orderDetail.transferSuccess())
-            .doesNotThrowAnyException();
-    }
-
     @DisplayName("OrderDetail의 orderStatus가 paid 아닌 경우 transferSuccess로 변경이 불가능하다.")
     @Test
     void toTransferSuccessFail() {
@@ -107,7 +94,7 @@ class OrderDetailTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> orderDetail.transferSuccess())
+        assertThatThrownBy(() -> orderDetail.transferSuccess("0x1234"))
             .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
## 작업 내용
1. **티켓 전송을 블록체인 상에서 한 후에, Entity에 이를 반영을 안했네요!!!!**
    - 블록체인 상에서 nft 전송이 완료된 후에, hash 값을 orderDetail에 저장합니다. 
    - 티켓의 주인이 주문자로 바뀌었으니, 엔티티 연관관계 매핑을 진행합니다. 
    - 어드민에서 한번 쓱 해봤는데 전송 잘 되더군요! 내일 같이 봐봅시다 :)

2. **민감 정보 => 파라미터 스토어로 넘기자**
    - jwt secret을 파라미터 스토어에서 관리합시다!

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
