### PR TITLE
feat: TicketSalesStatus 정보 동기화

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -56,9 +56,18 @@ public class Ticket {
 
     public void transferredTo(User user) {
         this.user = user;
+        this.soldOut();
     }
 
     public void toPending() {
         this.ticketSalesStatus = this.ticketSalesStatus.toPending();
+    }
+
+    public void soldOut() {
+        this.ticketSalesStatus = this.ticketSalesStatus.soldOut();
+    }
+
+    public void onSale() {
+        this.ticketSalesStatus = this.ticketSalesStatus.onSale();
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -57,4 +57,8 @@ public class Ticket {
     public void transferredTo(User user) {
         this.user = user;
     }
+
+    public void toPending() {
+        this.ticketSalesStatus = this.ticketSalesStatus.toPending();
+    }
 }

--- a/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
@@ -9,4 +9,18 @@ public enum TicketSalesStatus {
         }
         throw new IllegalArgumentException("ON SALE 상태만 PENDING으로 변할 수 있습니다.");
     }
+
+    public TicketSalesStatus soldOut() {
+        if (this.equals(PENDING)) {
+            return SOLD_OUT;
+        }
+        throw new IllegalArgumentException("PENDING 상태만 SOLD_OUT으로 변할 수 있습니다.");
+    }
+
+    public TicketSalesStatus onSale() {
+        if (this.equals(PENDING)) {
+            return ON_SALE;
+        }
+        throw new IllegalArgumentException("PENDING 상태만 ON_SALE로 변할 수 있습니다.");
+    }
 }

--- a/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
@@ -1,5 +1,12 @@
 package com.backend.connectable.event.domain;
 
 public enum TicketSalesStatus {
-    ON_SALE, PENDING, SOLD_OUT, EXPIRED
+    ON_SALE, PENDING, SOLD_OUT, EXPIRED;
+
+    public TicketSalesStatus toPending() {
+        if (this.equals(ON_SALE)) {
+            return PENDING;
+        }
+        throw new IllegalArgumentException("ON SALE 상태만 PENDING으로 변할 수 있습니다.");
+    }
 }

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -56,10 +56,12 @@ public class OrderDetail extends BaseEntity {
 
     public void unpaid() {
         this.orderStatus = orderStatus.toUnpaid();
+        this.ticket.onSale();
     }
 
     public void refund() {
         this.orderStatus = orderStatus.toRefund();
+        this.ticket.onSale();
     }
 
     public void transferSuccess(String txHash) {

--- a/src/main/java/com/backend/connectable/order/service/OrderService.java
+++ b/src/main/java/com/backend/connectable/order/service/OrderService.java
@@ -48,6 +48,7 @@ public class OrderService {
 
     private List<OrderDetail> generateOrderDetails(List<Long> ticketIds) {
         List<Ticket> tickets = ticketRepository.findAllById(ticketIds);
+        tickets.forEach(Ticket::toPending);
         return tickets.stream()
             .map(this::toOrderDetail)
             .collect(Collectors.toList());

--- a/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
@@ -118,7 +118,7 @@ class AdminServiceTest {
         .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/4.json")
         .tokenId(4)
         .price(100000)
-        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+        .ticketSalesStatus(TicketSalesStatus.PENDING)
         .ticketMetadata(joelTicket4Metadata)
         .build();
 
@@ -139,7 +139,7 @@ class AdminServiceTest {
         .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/5.json")
         .tokenId(5)
         .price(100000)
-        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+        .ticketSalesStatus(TicketSalesStatus.PENDING)
         .ticketMetadata(joelTicket5Metadata)
         .build();
 
@@ -184,6 +184,7 @@ class AdminServiceTest {
         assertThat(resultOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.TRANSFER_SUCCESS);
         assertThat(resultOrderDetail.getTxHash()).isEqualTo("0x1234abcd");
         assertThat(resultOrderDetail.getTicket().getUser().getId()).isEqualTo(joel.getId());
+        assertThat(resultOrderDetail.getTicket().getTicketSalesStatus()).isEqualTo(TicketSalesStatus.SOLD_OUT);
     }
 
     @DisplayName("OrderDetail의 ID에 대해 Unpaid로 상태를 변경할 수 있다.")
@@ -198,6 +199,7 @@ class AdminServiceTest {
         // then
         OrderDetail resultOrderDetail = orderDetailRepository.findById(orderDetailId).get();
         assertThat(resultOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.UNPAID);
+        assertThat(resultOrderDetail.getTicket().getTicketSalesStatus()).isEqualTo(TicketSalesStatus.ON_SALE);
     }
 
     @DisplayName("OrderDetail의 ID에 대해 Refund로 상태를 변경할 수 있다.")
@@ -212,6 +214,7 @@ class AdminServiceTest {
         // then
         OrderDetail resultOrderDetail = orderDetailRepository.findById(orderDetailId).get();
         assertThat(resultOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.REFUND);
+        assertThat(resultOrderDetail.getTicket().getTicketSalesStatus()).isEqualTo(TicketSalesStatus.ON_SALE);
     }
 
     @AfterEach

--- a/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
+++ b/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
@@ -1,5 +1,7 @@
 package com.backend.connectable.order.domain;
 
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketSalesStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -7,12 +9,17 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 class OrderDetailTest {
 
+    Ticket pendingTicket = Ticket.builder()
+        .ticketSalesStatus(TicketSalesStatus.PENDING)
+        .build();
+
     @DisplayName("OrderDetail의 orderStatus가 Request인 경우 Paid로 변경이 가능하다.")
     @Test
     void toPaid() {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.REQUESTED)
+            .ticket(pendingTicket)
             .build();
 
         // when
@@ -26,6 +33,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.TRANSFER_FAIL)
+            .ticket(pendingTicket)
             .build();
 
         // when & then
@@ -39,6 +47,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.REQUESTED)
+            .ticket(pendingTicket)
             .build();
 
         // when
@@ -52,6 +61,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.TRANSFER_FAIL)
+            .ticket(pendingTicket)
             .build();
 
         // when & then
@@ -65,6 +75,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.REQUESTED)
+            .ticket(pendingTicket)
             .build();
 
         // when
@@ -78,6 +89,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.TRANSFER_FAIL)
+            .ticket(pendingTicket)
             .build();
 
         // when & then
@@ -91,6 +103,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.REQUESTED)
+            .ticket(pendingTicket)
             .build();
 
         // when & then
@@ -104,6 +117,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.PAID)
+            .ticket(pendingTicket)
             .build();
 
         // when
@@ -117,6 +131,7 @@ class OrderDetailTest {
         // given
         OrderDetail orderDetail = OrderDetail.builder()
             .orderStatus(OrderStatus.REQUESTED)
+            .ticket(pendingTicket)
             .build();
 
         // when & then

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -150,7 +150,8 @@ class OrderServiceTest {
     void createOrder() {
         // given
         ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user);
-        OrderRequest orderRequest = new OrderRequest("이정필", "010-3333-7777", Arrays.asList(1L, 2L), 30000);
+        OrderRequest orderRequest = new OrderRequest("이정필", "010-3333-7777",
+            Arrays.asList(ticket1.getId(), ticket2.getId()), 30000);
 
         // when
         OrderResponse orderResponse = orderService.createOrder(connectableUserDetails, orderRequest);

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -10,7 +10,6 @@ import com.backend.connectable.order.ui.dto.OrderResponse;
 import com.backend.connectable.security.ConnectableUserDetails;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +21,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -133,7 +135,7 @@ class OrderServiceTest {
             .event(event)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
             .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
+            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
             .ticketMetadata(ticket2Metadata)
             .build();
 
@@ -145,7 +147,7 @@ class OrderServiceTest {
 
     @DisplayName("티켓을 구매하였을때, 주문정보 및 주문상세정보가 등록된다.")
     @Test
-    void registOrder() {
+    void createOrder() {
         // given
         ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user);
         OrderRequest orderRequest = new OrderRequest("이정필", "010-3333-7777", Arrays.asList(1L, 2L), 30000);
@@ -154,6 +156,10 @@ class OrderServiceTest {
         OrderResponse orderResponse = orderService.createOrder(connectableUserDetails, orderRequest);
 
         // then
-        Assertions.assertThat(orderResponse.getStatus()).isEqualTo("success");
+        assertThat(orderResponse.getStatus()).isEqualTo("success");
+        Ticket updatedTicket1 = ticketRepository.findById(ticket1.getId()).get();
+        Ticket updatedTicket2 = ticketRepository.findById(ticket2.getId()).get();
+        assertThat(updatedTicket1.getTicketSalesStatus()).isEqualTo(TicketSalesStatus.PENDING);
+        assertThat(updatedTicket2.getTicketSalesStatus()).isEqualTo(TicketSalesStatus.PENDING);
     }
 }


### PR DESCRIPTION
## 작업 내용
1. **티켓 주문 시 TicketSalesStatus 변경** 
    - ON_SALE => PENDING

2. **어드민에서 OrderDetail 정보 변경 시 TicketSalesStatus 변경**
    - PAID의 경우 : PENDING => SOLD_OUT
    - UNPAID | REFUND의 경우 : PENDING => ON_SALE

## 주의 사항
- 위에 제시된 시나리오가 아니면 예외가 발생합니다. 예외 처리 전략 수립시 리팩터링 필요.

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
