### PR TITLE
refactor: KAS를 통해 사용자 티켓 정보 조회

### DIFF
--- a/src/main/java/com/backend/connectable/artist/domain/Artist.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Artist.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -42,5 +43,18 @@ public class Artist {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.artistImage = artistImage;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Artist artist = (Artist) o;
+        return Objects.equals(id, artist.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/Event.java
+++ b/src/main/java/com/backend/connectable/event/domain/Event.java
@@ -70,4 +70,8 @@ public class Event {
         this.endTime = endTime;
         this.eventSalesOption = eventSalesOption;
     }
+
+    public String getArtistName() {
+        return this.artist.getArtistName();
+    }
 }

--- a/src/main/java/com/backend/connectable/event/domain/Event.java
+++ b/src/main/java/com/backend/connectable/event/domain/Event.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -73,5 +74,18 @@ public class Event {
 
     public String getArtistName() {
         return this.artist.getArtistName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Event event = (Event) o;
+        return Objects.equals(id, event.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -82,5 +83,18 @@ public class Ticket {
 
     public String getArtistName() {
         return this.event.getArtistName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Ticket ticket = (Ticket) o;
+        return Objects.equals(id, ticket.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -69,5 +70,17 @@ public class Ticket {
 
     public void onSale() {
         this.ticketSalesStatus = this.ticketSalesStatus.onSale();
+    }
+
+    public LocalDateTime getStartTime() {
+        return this.event.getStartTime();
+    }
+
+    public Long getEventId() {
+        return this.event.getId();
+    }
+
+    public String getArtistName() {
+        return this.event.getArtistName();
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepository.java
@@ -2,6 +2,13 @@ package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
+
+    @Query("select event.contractAddress " +
+            "from Event as event")
+    List<String> findAllContractAddresses();
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
@@ -2,6 +2,17 @@ package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    @Query("select distinct ticket " +
+        "from Ticket as ticket " +
+        "join fetch ticket.event as event " +
+        "join fetch event.artist as artist " +
+        "where ticket.tokenUri in :tokenUris")
+    List<Ticket> findAllByTokenUri(@Param("tokenUris") List<String> tokenUris);
 }

--- a/src/main/java/com/backend/connectable/kas/service/KasService.java
+++ b/src/main/java/com/backend/connectable/kas/service/KasService.java
@@ -16,6 +16,7 @@ import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 @Service
@@ -287,7 +288,7 @@ public class KasService {
         try {
             countDownLatch.await();
             return tokensResponses;
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | KasException e) {
             throw new IllegalArgumentException("비동기 처리에서 문제가 발생했습니다.");
         }
     }
@@ -296,6 +297,9 @@ public class KasService {
         return webClient.get()
             .uri(CONTRACT_API_URL + "/" + contractAddress + "/owner/" + userKlaytnAddress)
             .retrieve()
+            .onStatus(HttpStatus::is4xxClientError, response -> {
+                throw Objects.requireNonNull(response.bodyToMono(KasException.class).block());
+            })
             .bodyToMono(TokensResponse.class);
     }
 }

--- a/src/main/java/com/backend/connectable/kas/service/dto/TokensResponse.java
+++ b/src/main/java/com/backend/connectable/kas/service/dto/TokensResponse.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -14,4 +15,10 @@ import java.util.List;
 public class TokensResponse {
     private String cursor;
     private List<TokenResponse> items;
+
+    public List<String> getTokenUris() {
+        return items.stream()
+            .map(TokenResponse::getTokenUri)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/backend/connectable/order/domain/Order.java
+++ b/src/main/java/com/backend/connectable/order/domain/Order.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @NoArgsConstructor
@@ -43,5 +44,18 @@ public class Order extends BaseEntity {
         for (OrderDetail orderDetail : orderDetails) {
             orderDetail.setOrder(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Order order = (Order) o;
+        return Objects.equals(id, order.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -54,4 +54,17 @@ public class User {
     public boolean hasPhoneNumber() {
         return !Objects.isNull(phoneNumber);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/com/backend/connectable/user/ui/dto/UserTicketResponse.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserTicketResponse.java
@@ -1,11 +1,14 @@
 package com.backend.connectable.user.ui.dto;
 
+import com.backend.connectable.event.domain.Ticket;
 import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.backend.connectable.global.common.util.DateTimeUtil;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -38,5 +41,26 @@ public class UserTicketResponse {
         this.contractAddress = contractAddress;
         this.eventId = eventId;
         this.artistName = artistName;
+    }
+
+    public static List<UserTicketResponse> toList(List<Ticket> tickets) {
+        return tickets.stream()
+            .map(UserTicketResponse::of)
+            .collect(Collectors.toList());
+    }
+
+    public static UserTicketResponse of(Ticket ticket) {
+        return UserTicketResponse.builder()
+            .id(ticket.getId())
+            .price(ticket.getPrice())
+            .eventDate(ticket.getStartTime())
+            .ticketSalesStatus(ticket.getTicketSalesStatus())
+            .tokenId(ticket.getTokenId())
+            .tokenUri(ticket.getTokenUri())
+            .metadata(ticket.getTicketMetadata())
+            .contractAddress(ticket.getContractAddress())
+            .eventId(ticket.getEventId())
+            .artistName(ticket.getArtistName())
+            .build();
     }
 }

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.backend.connectable.event.domain.repository;
+
+import com.backend.connectable.artist.domain.Artist;
+import com.backend.connectable.artist.domain.repository.ArtistRepository;
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.EventSalesOption;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+
+@DataJpaTest
+class EventRepositoryTest {
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    ArtistRepository artistRepository;
+
+    Artist bigNaughty = Artist.builder()
+        .bankCompany("NH")
+        .bankAccount("9000000000099")
+        .artistName("빅나티")
+        .email("bignaughty@gmail.com")
+        .password("temptemp1234")
+        .phoneNumber("01012345678")
+        .artistImage("ARTIST_IMAGE")
+        .build();
+
+    String joelEventContractAddress = "0x1234";
+    Event joelEvent = Event.builder()
+        .description("조엘의 콘서트 at Connectable")
+        .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+        .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+        .contractAddress(joelEventContractAddress)
+        .eventName("조엘의 콘서트")
+        .eventImage("JOEL_EVENT_IMG_URL")
+        .twitterUrl("https://github.com/joelonsw")
+        .instagramUrl("https://www.instagram.com/jyoung_with/")
+        .webpageUrl("https://papimon.tistory.com/")
+        .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+        .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+        .eventSalesOption(EventSalesOption.FLAT_PRICE)
+        .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
+        .artist(bigNaughty)
+        .build();
+
+    String ryanEventContractAddress = "0x5678";
+    Event ryanEvent = Event.builder()
+        .description("라이언 콘서트 at Connectable")
+        .salesFrom(LocalDateTime.of(2022, 6, 11, 0, 0))
+        .salesTo(LocalDateTime.of(2022, 6, 17, 0, 0))
+        .contractAddress(ryanEventContractAddress)
+        .eventName("라이언 콘서트")
+        .eventImage("RYAN_EVENT_IMG_URL")
+        .twitterUrl("https://twitter.com/elonmusk")
+        .instagramUrl("https://www.instagram.com/eunbining0904/")
+        .webpageUrl("https://nextjs.org/")
+        .startTime(LocalDateTime.of(2022, 6, 22, 19, 30))
+        .endTime(LocalDateTime.of(2022, 6, 22, 21, 30))
+        .eventSalesOption(EventSalesOption.FLAT_PRICE)
+        .location("예술의 전당")
+        .artist(bigNaughty)
+        .build();
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+        artistRepository.deleteAll();
+
+        artistRepository.save(bigNaughty);
+        eventRepository.saveAll(Arrays.asList(joelEvent, ryanEvent));
+    }
+
+
+    @DisplayName("이벤트의 컨트랙트 주소를 받아올 수 있다.")
+    @Test
+    void findAllContractAddresses() {
+        List<String> allContractAddresses = eventRepository.findAllContractAddresses();
+        assertThat(allContractAddresses).contains(joelEventContractAddress, ryanEventContractAddress);
+    }
+}

--- a/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
@@ -13,7 +13,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,14 +82,25 @@ class TicketRepositoryTest {
             }})
             .build();
 
+    String tokenUri1 = "https://token.uri.1";
     Ticket joelTicket1 = Ticket.builder()
             .user(joel)
             .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
+            .tokenUri(tokenUri1)
             .price(100000)
             .ticketSalesStatus(TicketSalesStatus.ON_SALE)
             .ticketMetadata(joelTicket1Metadata)
             .build();
+
+    String tokenUri2 = "https://token.uri.2";
+    Ticket joelTicket2 = Ticket.builder()
+        .user(joel)
+        .event(joelEvent)
+        .tokenUri(tokenUri2)
+        .price(100000)
+        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+        .ticketMetadata(joelTicket1Metadata)
+        .build();
 
     @BeforeEach
     void setUp() {
@@ -109,5 +122,18 @@ class TicketRepositoryTest {
         assertThat(savedTicket.getTicketSalesStatus()).isEqualTo(TicketSalesStatus.ON_SALE);
         assertThat(savedTicket.getTicketMetadata().getName()).isEqualTo("조엘 콘서트 #1");
         assertThat(savedTicket.getTicketMetadata().getAttributes()).hasSize(3);
+    }
+
+    @DisplayName("Ticket을 tokenUri로 조회할 수 있다.")
+    @Test
+    void findTicketsByTokenUri() {
+        // given
+        ticketRepository.saveAll(Arrays.asList(joelTicket1, joelTicket2));
+
+        // when
+        List<Ticket> foundTickets = ticketRepository.findAllByTokenUri(Arrays.asList(tokenUri1, tokenUri2));
+
+        // then
+        assertThat(foundTickets).contains(joelTicket1, joelTicket2);
     }
 }

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.backend.connectable.artist.domain.repository.ArtistRepository;
 import com.backend.connectable.event.domain.*;
 import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.event.service.EventService;
 import com.backend.connectable.klip.service.KlipService;
 import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
 import com.backend.connectable.security.ConnectableUserDetails;
@@ -50,6 +51,9 @@ class UserServiceTest {
 
     @MockBean
     KlipService klipService;
+
+    @MockBean
+    EventService eventService;
 
     private User user1;
     private Artist artist1;
@@ -285,6 +289,7 @@ class UserServiceTest {
     @Test
     void getUserTicketsByUserDetails() {
         // given
+        given(eventService.findTicketByUserAddress(user1KlaytnAddress)).willReturn(Arrays.asList(ticket1, ticket2));
         ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
 
         // when


### PR DESCRIPTION
## 작업 내용
1. **KAS 에서 사용자의 티켓(토큰) 정보를 가져오도록 리팩터링합니다**
    - Flow는 다음과 같이 흘러갑니다
      - EventRepository 에서 ContractAddress 싹다 조회
      - KAS에 각 ContractAddress 별로 userKlaytnAddress에 대응되는 토큰이 있는지 API 호출
      - 결과값에서 tokenUri를 추출 
      - TicketRepository 에서 List<String\> tokenUris를 포함하는 친구들을 추출하여 List<Ticket\> 만듦
        - 여기서 JPQL을 통해 JoinFetch를 2번 써서 Ticket/Event/Artist를 한번에 땡겨옵니다

2. **엔티티의 ID를 기반으로 equals/hashcode 를 재정의합니다**

## 주의 사항
- 아 KAS 테스트하기 너무 어렵네요ㅜㅜㅜㅜㅜ 테스트하기 어려운 코드에 대해 테스트를 어찌할지 고민해봅시다!
- Dev 서버에 올라가야 제대로 테스트할 수 있을듯합니다,,,ㅜ

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
