### PR TITLE
feat: dataloader에서 새로운 nft 발행기능 구현

### DIFF
--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -5,13 +5,13 @@ import com.backend.connectable.artist.domain.repository.ArtistRepository;
 import com.backend.connectable.event.domain.*;
 import com.backend.connectable.event.domain.repository.EventRepository;
 import com.backend.connectable.event.domain.repository.TicketRepository;
-import com.backend.connectable.order.domain.Order;
-import com.backend.connectable.order.domain.OrderDetail;
-import com.backend.connectable.order.domain.OrderStatus;
-import com.backend.connectable.order.domain.repository.OrderRepository;
+import com.backend.connectable.kas.service.KasService;
+import com.backend.connectable.kas.service.dto.ContractItemResponse;
+import com.backend.connectable.s3.service.S3Service;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -20,385 +20,79 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 
 @Profile("dev")
 @Transactional
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DataLoader implements ApplicationRunner {
 
-    @Value("${kas.settings.account-pool-address}")
-    private String accountPoolAddress;
+    @Value("${dataloader.enable}")
+    private boolean enableDataloader;
 
+    private final KasService kasService;
+    private final S3Service s3Service;
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
     private final TicketRepository ticketRepository;
     private final ArtistRepository artistRepository;
-    private final OrderRepository orderRepository;
-
-    private static final String JOEL_EVENT_IMG_URL = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/image_0xtest.jpeg";
-    private static final String JOEL_EVENT_CONTRACT_ADDRESS = "0xa9dac3f1c04b55d7f8d6df115c47ecbc451c4692";
-
-    private static final String RYAN_EVENT_IMG_URL = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan.jpeg";
-    private static final String RYAN_EVENT_CONTRACT_ADDRESS = "0xe99540401ef24aba1b7076ea92c94ec38536c6fb";
-
-    private static final String JOEL_KLIP = "0x3AB31D219d45CE40d6862d68d37De6BB73E21a8D";
-    private static final String IHH_KLIP = "0xD466B3aafb86446FFC44868284a9FB76A0ae8BCb";
-    private static final String ARTIST_IMAGE = "https://user-images.githubusercontent.com/54073761/179218800-dda72067-3b25-4ca3-b53b-4895c5e49213.jpeg";
 
     @Override
-    public void run(ApplicationArguments args) {
-        User admin = User.builder()
-            .klaytnAddress(accountPoolAddress)
-            .nickname("어드민")
-            .phoneNumber("000-0000-0000")
-            .privacyAgreement(true)
-            .isActive(true)
-            .build();
+    public void run(ApplicationArguments args) throws InterruptedException {
+        if (enableDataloader) {
+            runDataLoader();
+        }
+    }
 
-        User joel = User.builder()
-            .klaytnAddress(JOEL_KLIP)
-            .nickname("조엘")
-            .phoneNumber("010-1234-5678")
-            .privacyAgreement(true)
-            .isActive(true)
-            .build();
+    private void runDataLoader() throws InterruptedException {
+        User admin = userRepository.findById(1L).get();
+        Artist bigNaughty = artistRepository.findById(1L).get();
 
-        User ihh = User.builder()
-            .klaytnAddress(IHH_KLIP)
-            .nickname("호현")
-            .phoneNumber("010-9898-8989")
-            .privacyAgreement(true)
-            .isActive(true)
-            .build();
-        userRepository.saveAll(Arrays.asList(admin, joel, ihh));
+        String name = "Brown At Connectable";
+        String symbol = "BAC";
+        String alias = "bac";
+        kasService.deployMyContract(name, symbol, alias);
+        Thread.sleep(3000);
 
-        Artist bigNaughty = Artist.builder()
-            .bankCompany("NH")
-            .bankAccount("9000000000099")
-            .artistName("빅나티")
-            .email("bignaughty@gmail.com")
-            .password("temptemp1234")
-            .phoneNumber("01012345678")
-            .artistImage(ARTIST_IMAGE)
-            .build();
-        artistRepository.save(bigNaughty);
+        ContractItemResponse contractItem = kasService.getMyContractMyAlias(alias);
+        String contractAddress = contractItem.getAddress();
+        log.info("$$ DEPLOYED CONTRACT ADDRESS : " + contractAddress + " $$");
 
-        Event joelEvent = Event.builder()
-            .description("조엘의 콘서트 at Connectable")
-            .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
-            .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
-            .contractAddress(JOEL_EVENT_CONTRACT_ADDRESS)
-            .eventName("조엘의 콘서트")
-            .eventImage(JOEL_EVENT_IMG_URL)
-            .twitterUrl("https://github.com/joelonsw")
-            .instagramUrl("https://www.instagram.com/jyoung_with/")
-            .webpageUrl("https://papimon.tistory.com/")
-            .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
-            .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
-            .eventSalesOption(EventSalesOption.FLAT_PRICE)
-            .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
-            .artist(bigNaughty)
-            .build();
-
-        Event ryanEvent = Event.builder()
-            .description("라이언 콘서트 at Connectable")
-            .salesFrom(LocalDateTime.of(2022, 6, 11, 0, 0))
-            .salesTo(LocalDateTime.of(2022, 6, 17, 0, 0))
-            .contractAddress(RYAN_EVENT_CONTRACT_ADDRESS)
-            .eventName("라이언 콘서트")
-            .eventImage(RYAN_EVENT_IMG_URL)
+        Event brownEvent = Event.builder()
+            .description("브라운 콘서트 at Connectable")
+            .salesFrom(LocalDateTime.of(2022, 8, 3, 0, 0))
+            .salesTo(LocalDateTime.of(2022, 10, 17, 0, 0))
+            .contractAddress(contractAddress)
+            .eventName("브라운 콘서트")
+            .eventImage("https://connectable-events.s3.ap-northeast-2.amazonaws.com/brown.jpeg")
             .twitterUrl("https://twitter.com/elonmusk")
             .instagramUrl("https://www.instagram.com/eunbining0904/")
             .webpageUrl("https://nextjs.org/")
-            .startTime(LocalDateTime.of(2022, 6, 22, 19, 30))
-            .endTime(LocalDateTime.of(2022, 6, 22, 21, 30))
+            .startTime(LocalDateTime.of(2022, 10, 17, 19, 30))
+            .endTime(LocalDateTime.of(2022, 10, 17, 21, 30))
             .eventSalesOption(EventSalesOption.FLAT_PRICE)
             .location("예술의 전당")
             .artist(bigNaughty)
             .build();
+        eventRepository.save(brownEvent);
 
-        eventRepository.saveAll(Arrays.asList(joelEvent, ryanEvent));
-
-        TicketMetadata joelTicket1Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #1")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test1.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A6");
-            }})
-            .build();
-
-        Ticket joelTicket1 = Ticket.builder()
-            .user(joel)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
-            .tokenId(1)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket1Metadata)
-            .build();
-
-        TicketMetadata joelTicket2Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #2")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test2.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A5");
-            }})
-            .build();
-
-        Ticket joelTicket2 = Ticket.builder()
-            .user(joel)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
-            .tokenId(2)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket2Metadata)
-            .build();
-
-        TicketMetadata joelTicket3Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #3")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test3.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A4");
-            }})
-            .build();
-
-        Ticket joelTicket3 = Ticket.builder()
-            .user(joel)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/3.json")
-            .tokenId(3)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket3Metadata)
-            .build();
-
-        TicketMetadata joelTicket4Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #4")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test4.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A3");
-            }})
-            .build();
-
-        Ticket joelTicket4 = Ticket.builder()
-            .user(joel)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/4.json")
-            .tokenId(4)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket4Metadata)
-            .build();
-
-        TicketMetadata joelTicket5Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #5")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test5.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A2");
-            }})
-            .build();
-
-        Ticket joelTicket5 = Ticket.builder()
-            .user(joel)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/5.json")
-            .tokenId(5)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket5Metadata)
-            .build();
-
-        TicketMetadata joelTicket6Metadata = TicketMetadata.builder()
-            .name("조엘 콘서트 #6")
-            .description("조엘의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test6.png")
-            .attributes(new HashMap<>(){{
-                put("Background", "Yellow");
-                put("Artist", "Joel");
-                put("Seat", "A1");
-            }})
-            .build();
-
-        Ticket joelTicket6 = Ticket.builder()
-            .user(ihh)
-            .event(joelEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/6.json")
-            .tokenId(6)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(joelTicket6Metadata)
-            .build();
-        ticketRepository.saveAll(Arrays.asList(joelTicket1, joelTicket2, joelTicket3, joelTicket4, joelTicket5, joelTicket6));
-
-        TicketMetadata ryanTicket1Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #1")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/1.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A2");
-            }})
-            .build();
-
-        Ticket ryanTicket1 = Ticket.builder()
-            .user(ihh)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/1.json")
-            .tokenId(1)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(ryanTicket1Metadata)
-            .build();
-
-        TicketMetadata ryanTicket2Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #2")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/2.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A6");
-            }})
-            .build();
-
-        Ticket ryanTicket2 = Ticket.builder()
-            .user(admin)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/2.json")
-            .tokenId(2)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-            .ticketMetadata(ryanTicket2Metadata)
-            .build();
-
-        TicketMetadata ryanTicket3Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #3")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/3.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A4");
-            }})
-            .build();
-
-        Ticket ryanTicket3 = Ticket.builder()
-            .user(admin)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/3.json")
-            .tokenId(3)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-            .ticketMetadata(ryanTicket3Metadata)
-            .build();
-
-        TicketMetadata ryanTicket4Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #4")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/4.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A3");
-            }})
-            .build();
-
-        Ticket ryanTicket4 = Ticket.builder()
-            .user(ihh)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/4.json")
-            .tokenId(4)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(ryanTicket4Metadata)
-            .build();
-
-        TicketMetadata ryanTicket5Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #5")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/5.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A1");
-            }})
-            .build();
-
-        Ticket ryanTicket5 = Ticket.builder()
-            .user(ihh)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/5.json")
-            .tokenId(5)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-            .ticketMetadata(ryanTicket5Metadata)
-            .build();
-
-        TicketMetadata ryanTicket6Metadata = TicketMetadata.builder()
-            .name("라이언 콘서트 #6")
-            .description("라이언의 콘서트 at Connectable")
-            .image("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/6.png")
-            .attributes(new HashMap<>(){{
-                put("Artist", "ryan");
-                put("Seat", "A5");
-            }})
-            .build();
-
-        Ticket ryanTicket6 = Ticket.builder()
-            .user(admin)
-            .event(ryanEvent)
-            .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/json/6.json")
-            .tokenId(6)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-            .ticketMetadata(ryanTicket6Metadata)
-            .build();
-
-        ticketRepository.saveAll(Arrays.asList(ryanTicket1, ryanTicket2, ryanTicket3, ryanTicket4, ryanTicket5, ryanTicket6));
-
-        Order order1 = Order.builder()
-            .user(joel)
-            .ordererName("조영상")
-            .ordererPhoneNumber("010-1234-5678")
-            .build();
-
-        OrderDetail orderDetail1 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x89cfee0a93fb59208da7f290507160720e4a9e71549d98b3d1064c6c2a671278", joelTicket1);
-        OrderDetail orderDetail2 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x4ca1775975b1e2ef06bff05e4a8d74b66b9397c05b1f3cfd105f4ba159c92371", joelTicket2);
-        OrderDetail orderDetail3 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x06abac950af4e26085c457119871fc318c852160c551010d9601cc44ea5dd41f", joelTicket3);
-        OrderDetail orderDetail4 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x5a79e442c91f49bad73ed753625a72e2043d3806682f69f1fcdbdead98a50a2f", joelTicket4);
-        OrderDetail orderDetail5 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x4a021da20180a607bc40c5e1065f96f61532b464e6e97266201e629dbc591321", joelTicket5);
-        OrderDetail orderDetail6 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0xd7b71e7d259a2b46d2f147b9763a534f51a0472c5cc726f68bc626eedd025e73", joelTicket6);
-        List<OrderDetail> order1Details = Arrays.asList(orderDetail1, orderDetail2, orderDetail3, orderDetail4, orderDetail5, orderDetail6);
-        order1.addOrderDetails(order1Details);
-
-        Order order2 = Order.builder()
-            .user(ihh)
-            .ordererName("이호현")
-            .ordererPhoneNumber("010-9876-5432")
-            .build();
-
-        OrderDetail orderDetail7 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x81ccf823b62c3b0edcd7bb6d47dcc951f87154fe832d7529029245070c844222", ryanTicket1);
-        OrderDetail orderDetail8 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x7ff47b4ca774124c603a9a826551f8a6e9a3e012cec1cd8ab9dffc2b1f45d142", ryanTicket4);
-        OrderDetail orderDetail9 = new OrderDetail(OrderStatus.TRANSFER_SUCCESS, "0x8aa08ec38c12ba9525e0dfb59e34e825e6d30c41c2e2fb51eb3e841e11d16a65", ryanTicket5);
-        List<OrderDetail> order2Details = Arrays.asList(orderDetail7, orderDetail8, orderDetail9);
-        order2.addOrderDetails(order2Details);
-
-        orderRepository.saveAll(Arrays.asList(order1, order2));
+        int totalTickets = 30;
+        for (int i = 1; i <= totalTickets; i++) {
+            String tokenUri = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/brown-event/json/" + i + ".json";
+            kasService.mintMyToken(contractAddress, i, tokenUri);
+            TicketMetadata ticketMetadata = s3Service.fetchMetadata(tokenUri)
+                .toTicketMetadata();
+            Ticket brownTicket = Ticket.builder()
+                .user(admin)
+                .event(brownEvent)
+                .tokenUri(tokenUri)
+                .tokenId(i)
+                .price(100000)
+                .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+                .ticketMetadata(ticketMetadata)
+                .build();
+            ticketRepository.save(brownTicket);
+        }
     }
 }

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketMetadataResponse.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -24,5 +26,16 @@ public class TicketMetadataResponse {
                 metadata.getImage(),
                 TicketMetadataAttributeResponse.toList(metadata.getAttributes())
         );
+    }
+
+    public TicketMetadata toTicketMetadata() {
+        Map<String, String> ticketMetadataAttribute = attributes.stream()
+            .collect(Collectors.toMap(TicketMetadataAttributeResponse::getTrait_type, TicketMetadataAttributeResponse::getValue));
+        return TicketMetadata.builder()
+            .name(name)
+            .description(description)
+            .image(image)
+            .attributes(ticketMetadataAttribute)
+            .build();
     }
 }

--- a/src/main/java/com/backend/connectable/kas/service/KasService.java
+++ b/src/main/java/com/backend/connectable/kas/service/KasService.java
@@ -130,6 +130,21 @@ public class KasService {
         return (ContractItemResponse) responseObject;
     }
 
+    public ContractItemResponse getMyContractMyAlias(String alias) {
+        Object responseObject = webClient.get()
+            .uri(CONTRACT_API_URL + "/" + alias)
+            .exchangeToMono(response -> {
+                if (response.statusCode().equals(HttpStatus.OK)) {
+                    return response.bodyToMono(ContractItemResponse.class);
+                }
+                return response.bodyToMono(KasExceptionResponse.class);
+            })
+            .block();
+
+        handleKasException(responseObject);
+        return (ContractItemResponse) responseObject;
+    }
+
     public TransactionResponse mintToken(String contractAddress, String tokenId, String tokenUri, String tokenOwner) {
         TokenRequest tokenRequest = TokenRequest.builder()
             .id(tokenId)
@@ -157,7 +172,7 @@ public class KasService {
     }
 
     public TransactionResponse mintMyToken(String contractAddress, int tokenId, String tokenUri) {
-        return mintToken(contractAddress, TOKEN_ID_PREFIX + tokenId, tokenUri, accountPoolAddress);
+        return mintToken(contractAddress, TOKEN_ID_PREFIX + Integer.toHexString(tokenId), tokenUri, accountPoolAddress);
     }
 
     public TokensResponse getTokens(String contractAddress) {
@@ -191,7 +206,7 @@ public class KasService {
     }
 
     public TokenResponse getToken(String contractAddress, int tokenId) {
-        return getToken(contractAddress, TOKEN_ID_PREFIX + tokenId);
+        return getToken(contractAddress, TOKEN_ID_PREFIX + Integer.toHexString(tokenId));
     }
 
     public TransactionResponse sendMyToken(String contractAddress, String tokenId, String receiver) {
@@ -217,7 +232,7 @@ public class KasService {
     }
 
     public TransactionResponse sendMyToken(String contractAddress, int tokenId, String receiver) {
-        return sendMyToken(contractAddress, TOKEN_ID_PREFIX + tokenId, receiver);
+        return sendMyToken(contractAddress, TOKEN_ID_PREFIX + Integer.toHexString(tokenId), receiver);
     }
 
     public TransactionResponse burnMyToken(String contractAddress, String tokenId) {
@@ -241,7 +256,7 @@ public class KasService {
     }
 
     public TransactionResponse burnMyToken(String contractAddress, int tokenId) {
-        return burnMyToken(contractAddress, TOKEN_ID_PREFIX + tokenId);
+        return burnMyToken(contractAddress, TOKEN_ID_PREFIX + Integer.toHexString(tokenId));
     }
 
     public TokenHistoriesResponse getTokenHistory(String contractAddress, String tokenId) {
@@ -260,7 +275,7 @@ public class KasService {
     }
 
     public TokenHistoriesResponse getTokenHistory(String contractAddress, int tokenId) {
-        return getTokenHistory(contractAddress, TOKEN_ID_PREFIX + tokenId);
+        return getTokenHistory(contractAddress, TOKEN_ID_PREFIX + Integer.toHexString(tokenId));
     }
 
     private void handleKasException(Object responseObject) {

--- a/src/main/java/com/backend/connectable/s3/service/S3Service.java
+++ b/src/main/java/com/backend/connectable/s3/service/S3Service.java
@@ -1,0 +1,16 @@
+package com.backend.connectable.s3.service;
+
+import com.backend.connectable.event.ui.dto.TicketMetadataResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class S3Service {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public TicketMetadataResponse fetchMetadata(String tokenUri) {
+        return restTemplate.getForEntity(tokenUri, TicketMetadataResponse.class)
+            .getBody();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,8 @@ kas:
     access-key-id: KASKOOU7SCEQTOSZ2FV0E9UQ
     secret-access-key: t-gAxJ_10sf7iqvo7qKxRIY6qUsyXMksMS6y0iY7
     chain-id: 1001
+dataloader:
+  enable: true
 ---
 spring:
   config:
@@ -88,3 +90,5 @@ kas:
     user-fee-payer-address: ${kas.user_fee_payer_address}
     access-key-id: ${kas.access_key_id}
     secret-access-key: ${kas.secret_access_key}
+dataloader:
+  enable: ${dataloader.enable}

--- a/src/test/java/com/backend/connectable/s3/service/S3ServiceTest.java
+++ b/src/test/java/com/backend/connectable/s3/service/S3ServiceTest.java
@@ -1,0 +1,39 @@
+package com.backend.connectable.s3.service;
+
+import com.backend.connectable.event.domain.TicketMetadata;
+import com.backend.connectable.event.ui.dto.TicketMetadataResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class S3ServiceTest {
+
+    @Autowired
+    S3Service s3Service;
+
+    @DisplayName("Url을 통해 nft의 메타데이터를 가져올 수 있다.")
+    @Test
+    void getMetadata() {
+        // given
+        String brownNft1TokenUri = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/brown-event/json/1.json";
+        String brownNft1Image = "https://connectable-events.s3.ap-northeast-2.amazonaws.com/ryan-event/images/1.png";
+
+        // when
+        TicketMetadataResponse ticketMetadataResponse = s3Service.fetchMetadata(brownNft1TokenUri);
+        TicketMetadata ticketMetadata = ticketMetadataResponse.toTicketMetadata();
+
+        // then
+        assertThat(ticketMetadata.getName()).isEqualTo("브라운 콘서트 #1");
+        assertThat(ticketMetadata.getDescription()).isEqualTo("브라운 콘서트 at Connectable");
+        assertThat(ticketMetadata.getImage()).isEqualTo(brownNft1Image);
+        assertThat(ticketMetadata.getAttributes().get(0).getTrait_type()).isEqualTo("Artist");
+        assertThat(ticketMetadata.getAttributes().get(0).getValue()).isEqualTo("brown");
+        assertThat(ticketMetadata.getAttributes().get(1).getTrait_type()).isEqualTo("Seat");
+        assertThat(ticketMetadata.getAttributes().get(1).getValue()).isEqualTo("A8");
+    }
+}


### PR DESCRIPTION
## 작업 내용
1. **KasService와 S3Service를 사용하여 새로운 티켓 민팅 기능을 데이터로더에 구현했습니다.**
  - 아마 MVP에서는 데이터 로더에 작성한 로직처럼 NFT를 민팅하고자 합니다. 
  - 미리 토큰 image와 토큰 uri를 만들어 S3에 업로드 한 후,
  - KasService에서 Contract를 만들어 클레이튼에 배포하고
  - KasService에서 Token을 1번 부터 차곡차곡 배포합니다. 
  - 나중에 어드민에서 해당 기능을 제공할 수 있도록 추후 기능 개발이 필요해보입니다. 

2. **S3Service를 구현합니다**
  - S3에서 토큰 uri를 가져옵니다. 
  - 현재로써는 그냥 url을 넣으면 정보를 가져오는 수준입니다. 
  - 나중에 이미지를 s3에 바로 업로드하는 기능등을 해당 클래스에 구현하면 좋을 듯 합니다. 

3. **Dataloader를 실행시킬지를 yaml에서 관리합니다**
  - yml 에 dataloader.enable 이라는 항목을 뒀습니다.
  - 파라미터 스토어에서 true/false를 제공하여 실제로 이를 구동 시킬지 말지를 결정하면 될 듯 합니다. 

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
