### PR TITLE
feat: 티켓 및 이벤트 정렬

### DIFF
--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -16,6 +16,7 @@ import com.backend.connectable.kas.service.KasService;
 import com.backend.connectable.kas.service.dto.TokenResponse;
 import com.backend.connectable.kas.service.dto.TokensResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -33,7 +34,7 @@ public class EventService {
     private final TicketRepository ticketRepository;
 
     public List<EventResponse> getList() {
-        List<Event> events = eventRepository.findAll();
+        List<Event> events = eventRepository.findAll(Sort.by(Sort.Direction.DESC, "salesTo"));
         return events.stream()
             .map(EventMapper.INSTANCE::eventToResponse)
             .collect(Collectors.toList());

--- a/src/test/java/com/backend/connectable/s3/service/S3ServiceTest.java
+++ b/src/test/java/com/backend/connectable/s3/service/S3ServiceTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class S3ServiceTest {


### PR DESCRIPTION
## 작업 내용
1. 이벤트 목록 조회시 EXPIRED 가 하위에 위치하도록 정렬
    * [Reference](https://www.baeldung.com/spring-data-sorting)를 참고하여, SalesTo 순으로 내림차순 정렬하였습니다. 
2. 티켓 목록 조회 시 ON_SALE(판매중), PENDING(유저가 구매폼 제출시), SOLD_OUT(판매완료), EXPIRED(이벤트 종료시) 순서로 INT VALUE를 주어 정렬되도록 하였습니다. 
    * [상기](https://stackoverflow.com/questions/67447083/querydsl-orderby-specific-string-values) 링크를 참고하여 작성하였습니다.

## 주의 사항
- 추후 시간별 정렬 순서에 대한 테스트 코드를 추가해보면 좋을 것 같습니다.

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
