### PR TITLE
refactor: 예외 처리 전략 수립

### DIFF
--- a/src/main/java/com/backend/connectable/admin/service/AdminService.java
+++ b/src/main/java/com/backend/connectable/admin/service/AdminService.java
@@ -1,11 +1,14 @@
 package com.backend.connectable.admin.service;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.exception.KasException;
 import com.backend.connectable.kas.service.KasService;
 import com.backend.connectable.kas.service.dto.TransactionResponse;
 import com.backend.connectable.order.domain.OrderDetail;
 import com.backend.connectable.order.domain.repository.OrderDetailRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +28,7 @@ public class AdminService {
 
     private OrderDetail findOrderDetail(Long orderDetailId) {
         return orderDetailRepository.findById(orderDetailId)
-            .orElseThrow(() -> new IllegalArgumentException("ID에 대응되는 주문 상세가 없습니다."));
+            .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_DETAIL_NOT_EXISTS));
     }
 
     private void sendTicket(OrderDetail orderDetail) {

--- a/src/main/java/com/backend/connectable/event/domain/TicketMetadataConverter.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketMetadataConverter.java
@@ -1,8 +1,11 @@
 package com.backend.connectable.event.domain;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
 
 import javax.persistence.AttributeConverter;
 import java.io.IOException;
@@ -17,7 +20,7 @@ public class TicketMetadataConverter implements AttributeConverter<TicketMetadat
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("티켓 메타데이터 -> JSON 실패");
+            throw new ConnectableException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorType.TICKET_METADATA_TO_JSON_FAILURE);
         }
     }
 
@@ -26,7 +29,7 @@ public class TicketMetadataConverter implements AttributeConverter<TicketMetadat
         try {
             return objectMapper.readValue(dbData, TicketMetadata.class);
         } catch (IOException e) {
-            throw new IllegalArgumentException("JSON -> 티켓 메타데이터 실패");
+            throw new ConnectableException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorType.TICKET_JSON_TO_METADATA_FAILURE);
         }
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
+++ b/src/main/java/com/backend/connectable/event/domain/TicketSalesStatus.java
@@ -1,5 +1,9 @@
 package com.backend.connectable.event.domain;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
+import org.springframework.http.HttpStatus;
+
 public enum TicketSalesStatus {
     ON_SALE, PENDING, SOLD_OUT, EXPIRED;
 
@@ -7,20 +11,20 @@ public enum TicketSalesStatus {
         if (this.equals(ON_SALE)) {
             return PENDING;
         }
-        throw new IllegalArgumentException("ON SALE 상태만 PENDING으로 변할 수 있습니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.TICKET_TO_PENDING_UNAVAILABLE);
     }
 
     public TicketSalesStatus soldOut() {
         if (this.equals(PENDING)) {
             return SOLD_OUT;
         }
-        throw new IllegalArgumentException("PENDING 상태만 SOLD_OUT으로 변할 수 있습니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.TICKET_TO_SOLD_OUT_UNAVAILABLE);
     }
 
     public TicketSalesStatus onSale() {
         if (this.equals(PENDING)) {
             return ON_SALE;
         }
-        throw new IllegalArgumentException("PENDING 상태만 ON_SALE로 변할 수 있습니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.TICKET_TO_ON_SALE_UNAVAILABLE);
     }
 }

--- a/src/main/java/com/backend/connectable/exception/ErrorType.java
+++ b/src/main/java/com/backend/connectable/exception/ErrorType.java
@@ -6,10 +6,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorType {
+    USER_NOT_FOUND("AUTH-001", "해당 유저를 찾을 수 없습니다."),
+    INVALID_TOKEN("AUTH-002", "유효하지 않은 토큰입니다."),
+    TOKEN_PAYLOAD_EXTRACTION_FAILURE("AUTH-003", "토큰 페이로드 추출에 실패했습니다"),
+
     MISSING_REQUIRED_VALUE_ERROR("COMMON-001", "필수 요청값이 누락되었습니다."),
     NOT_ALLOWED_PERMISSION_ERROR("COMMON-002", "허용되지 않은 권한입니다."),
     DUPLICATED_REQUEST_ERROR("COMMON-003", "중복된 요청입니다."),
     INVALID_REQUEST_ERROR("COMMON-004", "올바르지 않은 데이터 요청입니다."),
+    ASYNC_HANDLING_ERROR("COMMON-005", "비동기 처리에서 문제가 발생했습니다."),
 
     NICKNAME_FORMAT_ERROR("USER-001", "올바르지 않은 닉네임 입력 양식입니다."),
     EMAIL_FORMAT_ERROR("USER-002", "올바르지 않은 이메일 입력 양식입니다."),
@@ -20,8 +25,21 @@ public enum ErrorType {
 
     EVENT_NOT_EXISTS("EVENT-001", "존재하지 않는 이벤트입니다."),
 
-    TICKET_NOT_EXISTS("TICKET-001", "존재하지 않는 티켓입니다.")
-    ;
+    TICKET_NOT_EXISTS("TICKET-001", "존재하지 않는 티켓입니다."),
+    TICKET_TO_PENDING_UNAVAILABLE("TICKET-002", "ON SALE 상태만 PENDING으로 변할 수 있습니다."),
+    TICKET_TO_SOLD_OUT_UNAVAILABLE("TICKET-003", "PENDING 상태만 SOLD_OUT으로 변할 수 있습니다."),
+    TICKET_TO_ON_SALE_UNAVAILABLE("TICKET-004", "PENDING 상태만 ON_SALE로 변할 수 있습니다."),
+    TICKET_METADATA_TO_JSON_FAILURE("TICKET-005", "티켓 메타데이터를 JSON으로 변환하는데 실패했습니다"),
+    TICKET_JSON_TO_METADATA_FAILURE("TICKET-006", "JSON을 티켓 메타데이터로 변환하는데 실패했습니다"),
+
+    ORDER_TO_PAID_UNAVAILABLE("ORDER-001", "PAID 상태로 변경이 불가합니다."),
+    ORDER_TO_UNPAID_UNAVAILABLE("ORDER-002", "UNPAID 상태로 변경이 불가합니다."),
+    ORDER_TO_REFUND_UNAVAILABLE("ORDER-003", "REFUND 상태로 변경이 불가합니다."),
+    ORDER_TO_TRANSFER_SUCCESS_UNAVAILABLE("ORDER-004", "TRANSFER SUCCESS 상태로 변경이 불가합니다."),
+    ORDER_TO_TRANSFER_FAIL_UNAVAILABLE("ORDER-005", "TRANSFER FAIL 상태로 변경이 불가합니다."),
+
+    ORDER_DETAIL_NOT_EXISTS("ADMIN-001", "존재하지 않는 주문 상세입니다."),
+    ADMIN_TOKEN_VERIFY_FAILURE("ADMIN-002", "어드민 토큰이 아닙니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Arrays;
+
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
@@ -26,7 +28,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<MethodArgumentNotValidExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<MethodArgumentNotValidExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         MethodArgumentNotValidExceptionResponse errorResponse =  MethodArgumentNotValidExceptionResponse.of(ErrorType.INVALID_REQUEST_ERROR);
         for (FieldError fieldError: e.getFieldErrors()) {
             errorResponse.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
@@ -34,4 +36,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errorResponse);
     }
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        String errorMessage = e.getMessage();
+        Arrays.stream(e.getStackTrace())
+                .map(StackTraceElement::toString)
+                .forEach(log::error);
+        return ResponseEntity.internalServerError().body(errorMessage);
+    }
 }

--- a/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ConnectableException.class)
@@ -16,9 +18,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(KasException.class)
     public ResponseEntity<KasExceptionResponse> handleKasException(KasException e) {
-        return ResponseEntity.badRequest().body(e.getKasExceptionResponse());
+        KasExceptionResponse kasExceptionResponse = e.getKasExceptionResponse();
+        log.error("KAS Request ID: " + kasExceptionResponse.getRequestId());
+        log.error("KAS Code: " + kasExceptionResponse.getCode());
+        log.error("KAS Message: " + kasExceptionResponse.getMessage());
+        return ResponseEntity.internalServerError().body(kasExceptionResponse);
     }
-
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<MethodArgumentNotValidExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/com/backend/connectable/kas/service/KasService.java
+++ b/src/main/java/com/backend/connectable/kas/service/KasService.java
@@ -1,5 +1,7 @@
 package com.backend.connectable.kas.service;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.exception.KasException;
 import com.backend.connectable.exception.KasExceptionResponse;
 import com.backend.connectable.kas.service.dto.*;
@@ -281,9 +283,6 @@ public class KasService {
     private void handleKasException(Object responseObject) {
         if (responseObject instanceof KasExceptionResponse) {
             KasExceptionResponse kasExceptionResponse = (KasExceptionResponse) responseObject;
-            log.error("KAS Request ID: " + kasExceptionResponse.getRequestId());
-            log.error("KAS Code: " + kasExceptionResponse.getCode());
-            log.error("KAS Message: " + kasExceptionResponse.getMessage());
             throw new KasException(kasExceptionResponse);
         }
     }
@@ -303,8 +302,8 @@ public class KasService {
         try {
             countDownLatch.await();
             return tokensResponses;
-        } catch (InterruptedException | KasException e) {
-            throw new IllegalArgumentException("비동기 처리에서 문제가 발생했습니다.");
+        } catch (InterruptedException e) {
+            throw new ConnectableException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorType.ASYNC_HANDLING_ERROR);
         }
     }
 

--- a/src/main/java/com/backend/connectable/order/domain/OrderStatus.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderStatus.java
@@ -1,5 +1,9 @@
 package com.backend.connectable.order.domain;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
+import org.springframework.http.HttpStatus;
+
 public enum OrderStatus {
 
     REQUESTED, PAID, UNPAID, REFUND, TRANSFER_SUCCESS, TRANSFER_FAIL;
@@ -16,34 +20,34 @@ public enum OrderStatus {
         if (this.isRequested()) {
             return PAID;
         }
-        throw new IllegalArgumentException("PAID 상태로 변경이 불가합니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_TO_PAID_UNAVAILABLE);
     }
 
     public OrderStatus toUnpaid() {
         if (this.isRequested()) {
             return UNPAID;
         }
-        throw new IllegalArgumentException("UNPAID 상태로 변경이 불가합니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_TO_UNPAID_UNAVAILABLE);
     }
 
     public OrderStatus toRefund() {
         if (this.isRequested()) {
             return REFUND;
         }
-        throw new IllegalArgumentException("REFUND 상태로 변경이 불가합니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_TO_REFUND_UNAVAILABLE);
     }
 
     public OrderStatus toTransferSuccess() {
         if (this.isPaid()) {
             return TRANSFER_SUCCESS;
         }
-        throw new IllegalArgumentException("TRANSFER SUCCESS 상태로 변경이 불가합니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_TO_TRANSFER_SUCCESS_UNAVAILABLE);
     }
 
     public OrderStatus toTransferFail() {
         if (this.isPaid()) {
             return TRANSFER_FAIL;
         }
-        throw new IllegalArgumentException("TRANSFER FAIL 상태로 변경이 불가합니다.");
+        throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ORDER_TO_TRANSFER_FAIL_UNAVAILABLE);
     }
 }

--- a/src/main/java/com/backend/connectable/s3/service/S3Service.java
+++ b/src/main/java/com/backend/connectable/s3/service/S3Service.java
@@ -10,7 +10,6 @@ public class S3Service {
     private final RestTemplate restTemplate = new RestTemplate();
 
     public TicketMetadataResponse fetchMetadata(String tokenUri) {
-        return restTemplate.getForEntity(tokenUri, TicketMetadataResponse.class)
-            .getBody();
+        return restTemplate.getForEntity(tokenUri, TicketMetadataResponse.class).getBody();
     }
 }

--- a/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
+++ b/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
@@ -1,8 +1,11 @@
 package com.backend.connectable.security;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,6 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String klaytnAddress) throws UsernameNotFoundException {
         Optional<User> optionalUser = userRepository.findByKlaytnAddress(klaytnAddress);
         return optionalUser.map(ConnectableUserDetails::new)
-                .orElseThrow(() -> new IllegalAccessError("로그인 실패!"));
+                .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/connectable/security/JwtProvider.java
+++ b/src/main/java/com/backend/connectable/security/JwtProvider.java
@@ -4,8 +4,11 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -50,7 +53,7 @@ public class JwtProvider {
                 .build()
                 .verify(token);
         } catch (JWTVerificationException e) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.INVALID_TOKEN);
         }
     }
 
@@ -59,7 +62,7 @@ public class JwtProvider {
              return JWT.decode(token)
                 .getSubject();
         } catch (JWTDecodeException e) {
-            throw new IllegalArgumentException("토큰 디코딩에 실패하였습니다.");
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.TOKEN_PAYLOAD_EXTRACTION_FAILURE);
         }
     }
 
@@ -71,7 +74,7 @@ public class JwtProvider {
     public void verifyAdmin(String token) {
         String adminPayload = exportClaim(token);
         if (!this.adminPayload.equals(adminPayload)) {
-            throw new IllegalArgumentException("어드민 토큰이 아닙니다.");
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ADMIN_TOKEN_VERIFY_FAILURE);
         }
     }
 }

--- a/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
+++ b/src/test/java/com/backend/connectable/order/domain/OrderDetailTest.java
@@ -2,6 +2,7 @@ package com.backend.connectable.order.domain;
 
 import com.backend.connectable.event.domain.Ticket;
 import com.backend.connectable.event.domain.TicketSalesStatus;
+import com.backend.connectable.exception.ConnectableException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,7 @@ class OrderDetailTest {
 
         // when & then
         assertThatThrownBy(() -> orderDetail.paid())
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 
     @DisplayName("OrderDetail의 orderStatus가 Request인 경우 unpaid로 변경이 가능하다.")
@@ -67,7 +68,7 @@ class OrderDetailTest {
 
         // when & then
         assertThatThrownBy(() -> orderDetail.unpaid())
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 
     @DisplayName("OrderDetail의 orderStatus가 Request인 경우 refund로 변경이 가능하다.")
@@ -95,7 +96,7 @@ class OrderDetailTest {
 
         // when & then
         assertThatThrownBy(() -> orderDetail.refund())
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 
     @DisplayName("OrderDetail의 orderStatus가 paid 아닌 경우 transferSuccess로 변경이 불가능하다.")
@@ -109,7 +110,7 @@ class OrderDetailTest {
 
         // when & then
         assertThatThrownBy(() -> orderDetail.transferSuccess("0x1234"))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 
     @DisplayName("OrderDetail의 orderStatus가 paid 경우 transferFail로 변경이 가능하다.")
@@ -137,6 +138,6 @@ class OrderDetailTest {
 
         // when & then
         assertThatThrownBy(() -> orderDetail.transferFail())
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 }

--- a/src/test/java/com/backend/connectable/security/JwtProviderTest.java
+++ b/src/test/java/com/backend/connectable/security/JwtProviderTest.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.security;
 
+import com.backend.connectable.exception.ConnectableException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,7 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.verify(token))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(ConnectableException.class);
     }
 
     @Test
@@ -76,7 +77,7 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.exportClaim(invalidToken))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 
     @DisplayName("어드민 JWT 토큰에 대해 verify 할 수 있다.")
@@ -98,6 +99,6 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.verifyAdmin(adminToken))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(ConnectableException.class);
     }
 }


### PR DESCRIPTION
## 작업 내용
1. **예외 처리 전략을 수립하였습니다.**
    - Enum으로 ErrorType을 관리합니다. 
    - RuntimeException을 상속받은 ConnectableException을 정의해, HttpStatus와 ErrorType을 필드로 가지게 합니다. 
    - 전역 ControllerAdvice에서 Exception을 잡아 ResponseEntity로 상태 코드와 바디를 응답해줍니다. 

2. **ControllerAdvice에서 예외를 잡아 처리합니다**
    - 서비스에서 정의한 아래와 같은 예외를 처리합니다.
        - ConnectableException
        - KasException
        - MethodArgumentNotValidException
    - 서비스에서 정의한 예외를 벗어난 예외라면 Exception을 잡는 핸들러에서 처리합니다. 
        - 이 과정에서 error 레벨로 예외에 대한 스택 트레이스를 로그로 기록합니다. 

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
