### PR TITLE
refactor: Opensea Collection Url 추가

### DIFF
--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -12,7 +12,9 @@ import com.backend.connectable.event.ui.dto.EventResponse;
 import com.backend.connectable.event.ui.dto.TicketResponse;
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
+import com.backend.connectable.global.common.util.OpenseaCollectionNamingUtil;
 import com.backend.connectable.kas.service.KasService;
+import com.backend.connectable.kas.service.dto.ContractItemResponse;
 import com.backend.connectable.kas.service.dto.TokenResponse;
 import com.backend.connectable.kas.service.dto.TokensResponse;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +45,14 @@ public class EventService {
     public EventDetailResponse getEventDetail(Long eventId) {
         EventDetail eventDetail = eventRepository.findEventDetailByEventId(eventId)
             .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.EVENT_NOT_EXISTS));
-        return EventMapper.INSTANCE.eventDetailToResponse(eventDetail);
+        EventDetailResponse eventDetailResponse = EventMapper.INSTANCE.eventDetailToResponse(eventDetail);
+
+        // Todo : Contract Name을 DB에 저장할 것
+        ContractItemResponse eventContractInformation = kasService.getMyContract(eventDetail.getContractAddress());
+        String contractName = eventContractInformation.getName();
+        String openseaUrl = OpenseaCollectionNamingUtil.toOpenseaCollectionUrl(contractName);
+        eventDetailResponse.setOpenseaUrl(openseaUrl);
+        return eventDetailResponse;
     }
 
     public List<TicketResponse> getTicketList(Long eventId) {

--- a/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
@@ -33,6 +33,7 @@ public class EventDetailResponse {
     private int price;
     private String location;
     private EventSalesOption eventSalesOption;
+    private String openseaUrl;
 
     @Builder
     public EventDetailResponse(Long id, String name, String image, String artistName, String artistImage, String description,
@@ -58,5 +59,9 @@ public class EventDetailResponse {
         this.price = price;
         this.location = location;
         this.eventSalesOption = eventSalesOption;
+    }
+
+    public void setOpenseaUrl(String openseaUrl) {
+        this.openseaUrl = openseaUrl;
     }
 }

--- a/src/main/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtil.java
+++ b/src/main/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtil.java
@@ -1,0 +1,18 @@
+package com.backend.connectable.global.common.util;
+
+public class OpenseaCollectionNamingUtil {
+
+    private static final String OPENSEA_COLLECTION_URL = "https://opensea.io/collection/";
+
+    private OpenseaCollectionNamingUtil() {
+    }
+
+    public static String toOpenseaCollectionUrl(String contractName) {
+        contractName = convertToOpenseaCollectionFormat(contractName);
+        return OPENSEA_COLLECTION_URL + contractName;
+    }
+
+    private static String convertToOpenseaCollectionFormat(String contractName) {
+        return contractName.toLowerCase().replaceAll("\\s+", "-");
+    }
+}

--- a/src/test/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtilTest.java
+++ b/src/test/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtilTest.java
@@ -1,0 +1,23 @@
+package com.backend.connectable.global.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenseaCollectionNamingUtilTest {
+
+    @DisplayName("Opensea Collection Url로 해당 NFT Name을 변경할 수 있다.")
+    @Test
+    void toOpenseaCollectionUrl() {
+        // given
+        String contractName = "Connectable Dev NFT";
+
+        // when
+        String openseaUrl = OpenseaCollectionNamingUtil.toOpenseaCollectionUrl(contractName);
+
+        // then
+        assertThat(openseaUrl).isEqualTo("https://opensea.io/collection/connectable-dev-nft");
+    }
+}

--- a/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
+++ b/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
@@ -29,6 +29,13 @@ class KasServiceTest {
     public String poolAddress;
 
     @Test
+    void getContractInfo() {
+        ContractItemResponse myContract = kasService.getMyContract(NEW_CONTRACT_ADDRESS);
+        System.out.println("myContract.getAlias() = " + myContract.getAlias());
+        System.out.println("myContract.getName() = " + myContract.getName());
+    }
+
+    @Test
     void findAllTokensOfContractAddressesOwnedByUser() throws InterruptedException {
         ContractItemsResponse myContracts = kasService.getMyContracts();
         List<String> myContractAddresses  = myContracts.getItems().stream()


### PR DESCRIPTION
## 작업 내용
1. **KasService에서 ContractAddress를 통해 Contract 정보를 가지고 옵니다**
    - 가지고 온 Contract 정보에서 Name을 추출한 뒤, 이를 Opensea Collection Url 정보에 맞게 바꿔줍니다. 

2. **관심사의 분리를 위해 OpenseaCollectionNamingUtil을 만들었습니다**
    - 컬렉션에 대응되는 opensea url을 opensea의 현재 규격에 맞게 변환하는 util클래스를 따로 global/common에 분리하여 구현하였습니다. 

## 주의 사항
- 매번 KAS를 찔러 Contract 정보 가져오는건 비효율적입니다! 초장부터 Event 저장에 Contract Name을 같이 저장하도록 리팩터링이 필요합니다. Todo로 작성해뒀습니다~

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
