### PR TITLE
refactor: 트랜잭션 어노테이션 정책에 따라 변경 및 단건 더티체킹

### DIFF
--- a/src/main/java/com/backend/connectable/admin/service/AdminService.java
+++ b/src/main/java/com/backend/connectable/admin/service/AdminService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminService {
 
     private final OrderDetailRepository orderDetailRepository;

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
@@ -21,7 +20,6 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    @Transactional
     public long modifyTicketSalesStatusExpire() {
         long fetchedRowCount = queryFactory
             .update(ticket)

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventService {
 
     private final KasService kasService;

--- a/src/main/java/com/backend/connectable/order/service/OrderService.java
+++ b/src/main/java/com/backend/connectable/order/service/OrderService.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class OrderService {
 
     private final OrderRepository orderRepository;

--- a/src/main/java/com/backend/connectable/schedule/ScheduledTasks.java
+++ b/src/main/java/com/backend/connectable/schedule/ScheduledTasks.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class ScheduledTasks {
     private final TicketRepository ticketRepository;
 
     @Scheduled(cron = "0 0 10 * * *")
+    @Transactional
     public void expireTickets() {
         log.info("##RUNNING##EXPIRE_TICKET_STATUS");
         long fetchedCount = ticketRepository.modifyTicketSalesStatusExpire();

--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -10,9 +10,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import java.util.Objects;
 
-@Entity
 @Getter
 @NoArgsConstructor
+@Entity
 public class User {
 
     @Id

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
@@ -1,14 +1,8 @@
 package com.backend.connectable.user.domain.repository;
 
-import com.backend.connectable.user.domain.dto.UserTicket;
-
-import java.util.List;
-
 public interface UserRepositoryCustom {
 
     void deleteUser(String klaytnAddress);
 
     void modifyUser(String klaytnAddress, String nickname, String phoneNumber);
-
-    List<UserTicket> getOwnTicketsByUser(Long userId);
 }

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
@@ -1,17 +1,10 @@
 package com.backend.connectable.user.domain.repository;
 
-import com.backend.connectable.user.domain.dto.UserTicket;
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-import java.util.List;
 
-import static com.backend.connectable.artist.domain.QArtist.artist;
-import static com.backend.connectable.event.domain.QEvent.event;
-import static com.backend.connectable.event.domain.QTicket.ticket;
 import static com.backend.connectable.user.domain.QUser.user;
 
 @Repository
@@ -23,7 +16,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    @Transactional
     public void deleteUser(String klaytnAddress) {
         queryFactory
             .update(user)
@@ -32,7 +24,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             .execute();
     }
 
-    @Transactional
     public void modifyUser(String klaytnAddress, String nickname, String phoneNumber) {
         queryFactory
             .update(user)
@@ -40,29 +31,5 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             .set(user.phoneNumber, phoneNumber)
             .where(user.klaytnAddress.eq(klaytnAddress))
             .execute();
-    }
-
-    @Override
-    public List<UserTicket> getOwnTicketsByUser(Long userId) {
-        return queryFactory.select(Projections.constructor(
-            UserTicket.class,
-            ticket.id,
-            ticket.price,
-            event.startTime.as("eventDate"),
-            event.eventName,
-            ticket.ticketSalesStatus,
-            ticket.tokenId,
-            ticket.tokenUri,
-            ticket.ticketMetadata,
-            event.contractAddress,
-            event.id.as("eventId"),
-            artist.artistName
-            ))
-            .from(ticket)
-            .leftJoin(user).on(user.id.eq(ticket.user.id))
-            .innerJoin(event).on(ticket.event.id.eq(event.id))
-            .innerJoin(artist).on(event.artist.id.eq(artist.id))
-            .where(user.id.eq(userId))
-            .fetch();
     }
 }

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 @Slf4j
 public class UserService {
 
@@ -74,16 +74,20 @@ public class UserService {
         return UserResponse.ofFailure(user);
     }
 
+    @Transactional
     public UserModifyResponse deleteUserByUserDetails(ConnectableUserDetails userDetails) {
         User user = userDetails.getUser();
         userRepository.deleteUser(user.getKlaytnAddress());
         return UserModifyResponse.ofSuccess();
     }
 
+    @Transactional
     public UserModifyResponse modifyUserByUserDetails(ConnectableUserDetails userDetails, UserModifyRequest userModifyRequest) {
         User user = userDetails.getUser();
         log.info("@@USER_DETAILS_USER_OBJECT::{}", user);
-        userRepository.modifyUser(user.getKlaytnAddress(), userModifyRequest.getNickname(), userModifyRequest.getPhoneNumber());
+        user.modifyNickname(userModifyRequest.getNickname());
+        user.modifyPhoneNumber(userModifyRequest.getPhoneNumber());
+//        userRepository.modifyUser(user.getKlaytnAddress(), userModifyRequest.getNickname(), userModifyRequest.getPhoneNumber());
         return UserModifyResponse.ofSuccess();
     }
 

--- a/src/test/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtilTest.java
+++ b/src/test/java/com/backend/connectable/global/common/util/OpenseaCollectionNamingUtilTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class OpenseaCollectionNamingUtilTest {
 

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -198,6 +198,7 @@ class UserServiceTest {
         UserModifyResponse userModifyResponse = userService.modifyUserByUserDetails(connectableUserDetails, userModifyRequest);
 
         // then
+        assertThat(connectableUserDetails.getUser().getNickname()).isEqualTo("mrlee7");
         assertThat(userModifyResponse.getStatus()).isEqualTo("success");
     }
 


### PR DESCRIPTION
## 작업 내용
- 클래스 단위는 읽기 전용 Connection 맺도록 변경 및, 쓰기단위는 메소드 단위로 Transactional 어노테이션 붙임
- 모든 Transactional 어노테이션은 비즈니스 로직에 붙도록 함.
- 단건 As-Is : QueryDsl , To-Be : Dirty Checking

변경 사항등에 대해서는 Tech Spec 문서에 기입하였습니다. [링크 바로가기](https://www.notion.so/Transaction-fbb9388c6cd943abb75c60d131dc4292)

## 주의 사항
- 로직 변경으로 getOwnTicketsByUser 메소드 사용하지 않음에 따라 삭제 처리함
+) Dirty-Checking 방식이 이슈 없을 경우 UserService > modifyUser도 삭제 예정
- CheckedException ( SQLException, ... ) 에 대해서는 롤백되지 않는 부분에 대한 고민 필요
- 이외의 Unique Key, FK 등의 이슈에 대한 전반적인 점검 필요

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
