### PR TITLE
fix: 유저 수정 queryDsl 로 변경

### DIFF
--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -39,14 +39,6 @@ public class User {
         this.isActive = isActive;
     }
 
-    public void modifyNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public void modifyPhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
-
     public boolean hasNickname() {
         return !Objects.isNull(nickname);
     }

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -86,9 +86,7 @@ public class UserService {
     public UserModifyResponse modifyUserByUserDetails(ConnectableUserDetails userDetails, UserModifyRequest userModifyRequest) {
         User user = userDetails.getUser();
         log.info("@@USER_DETAILS_USER_OBJECT::{}", user);
-        user.modifyNickname(userModifyRequest.getNickname());
-        user.modifyPhoneNumber(userModifyRequest.getPhoneNumber());
-//        userRepository.modifyUser(user.getKlaytnAddress(), userModifyRequest.getNickname(), userModifyRequest.getPhoneNumber());
+        userRepository.modifyUser(user.getKlaytnAddress(), userModifyRequest.getNickname(), userModifyRequest.getPhoneNumber());
         return UserModifyResponse.ofSuccess();
     }
 

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -198,7 +198,6 @@ class UserServiceTest {
         UserModifyResponse userModifyResponse = userService.modifyUserByUserDetails(connectableUserDetails, userModifyRequest);
 
         // then
-        assertThat(connectableUserDetails.getUser().getNickname()).isEqualTo("mrlee7");
         assertThat(userModifyResponse.getStatus()).isEqualTo("success");
     }
 


### PR DESCRIPTION
## 작업 내용
- Dirty Checking이 동작하지 않음으로, QueryDsl 을 사용하여 유저 수정하도록 변경
    - 인증/인가 과정에서 SimpleJpaRepository를 사용하여 readOnly 옵션을 사용함에 따라 , 유저 엔티티 정보를 스냅샷으로 찍지않기에 더티 체킹이 동작하지 않음
    - 해서, QueryDsl 로 쿼리가 수행되도록 함.

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
