### PR TITLE
feat: 로깅 전략 수립

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: local
     group:
-      dev: slack-paid-logging, console-logging
+      dev: console-logging,file-sql-logging,file-info-logging,file-error-logging,slack-dev-error-logging,slack-paid-logging
 ---
 spring:
   config:
@@ -82,8 +82,15 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+    org.springframework.orm: TRACE
+    org.springframework.transaction: TRACE
+    com.zaxxer.hikari: TRACE
+    com.mysql.cj.jdbc: TRACE
   slack:
-    webhook-uri: ${slack.paid_channel_uri}
+    webhook-uri-dev-paid: ${slack.paid_channel_uri}
+    webhook-uri-dev-error: ${slack.error_channel_uri}
+  file:
+    path: /home/ubuntu
   config: classpath:logback-spring.xml
 kas:
   settings:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -11,9 +11,91 @@
         </appender>
     </springProfile>
 
+    <springProfile name="file-sql-logging">
+        <appender name="local-file-logger" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/logs/connectable-sql.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/logs/dateLog/%d{yyyy_MM_dd}_%i.connectable-sql.log
+                </fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <charset>utf8</charset>
+                <Pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%logger{36}] - %m%n</Pattern>
+            </encoder>
+        </appender>
+
+        <logger name="org.hibernate.SQL" level="TRACE">
+            <appender-ref ref="local-file-logger"/>
+        </logger>
+        <logger name="org.hibernate.type.descriptor" level="TRACE">
+            <appender-ref ref="local-file-logger"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="file-info-logging">
+        <appender name="INFO_FILE_POLICY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+            <file>${LOG_PATH}/logs/connectable-info.log</file>
+            <encoder>
+                <charset>utf8</charset>
+                <Pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%logger{36}] - %m%n</Pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/logs/dateLog/%d{yyyy_MM_dd}_%i.connectable-info.log
+                </fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+    </springProfile>
+
+    <springProfile name="file-error-logging">
+        <appender name="ERROR_FILE_POLICY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+            <file>${LOG_PATH}/logs/connectable-error.log</file>
+            <encoder>
+                <charset>utf8</charset>
+                <Pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%logger{36}] - %m%n</Pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/logs/dateLog/%d{yyyy_MM_dd}_%i.connectable-error.log
+                </fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+    </springProfile>
+
+    <springProfile name="slack-dev-error-logging">
+        <springProperty name="devErrorSlackUri" source="logging.slack.webhook-uri-dev-error" />
+        <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+            <webhookUri>${devErrorSlackUri}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>[DEV] %-4relative [%thread] %-5level %class - %msg%n</pattern>
+            </layout>
+            <colorCoding>true</colorCoding>
+        </appender>
+        <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="SLACK"/>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+    </springProfile>
+
     <springProfile name="slack-paid-logging">
+        <springProperty name="devPaidSlackUri" source="logging.slack.webhook-uri-dev-paid" />
         <appender name="DEV_PAID_USER_SLACK_NOTI" class="com.github.maricn.logback.SlackAppender">
-            <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+            <webhookUri>${devPaidSlackUri}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>[ALARM]%d{yyyy-MM-dd HH:mm:ss.SSS} : %msg%n</pattern>
             </layout>
@@ -31,7 +113,20 @@
         <springProfile name="console-logging">
             <appender-ref ref="STDOUT"/>
         </springProfile>
+
+        <springProfile name="file-info-logging">
+            <appender-ref ref="INFO_FILE_POLICY"/>
+        </springProfile>
+
+        <springProfile name="file-error-logging">
+            <appender-ref ref="ERROR_FILE_POLICY"/>
+        </springProfile>
+
+        <springProfile name="slack-dev-error-logging">
+            <appender-ref ref="ASYNC_SLACK"/>
+        </springProfile>
     </root>
+
     <logger name="com.backend.connectable.order.ui.OrderController" level="INFO">
         <springProfile name="slack-paid-logging">
             <appender-ref ref="DEV_ASYNC_SLACK"/>


### PR DESCRIPTION
## 작업 내용
1. **로깅 전략을 수립합니다**
    - 재사용할 수 있는 logback appender를 만들었습니다. 
    - sql_log/info_log/error_log를 각각 최근 7일 동안만 서버에 저장해두도록 xml을 설정했습니다
    - Error 레벨의 로그가 발생한다면 slack에 웹훅을 통해 알림을 줍니다. 
    - 주문이 들어오는 슬랙채널과 Dev Error 로그 발생시 알림을 주는 슬랙채널을 분리해야한다고 생각하여 이를 분리하였습니다. 주의 사항에 삽질 조금 적었습니다. 

2. **Dev서버에 로그를 대량으로 찍어둡니다**
    - 실시간 디버깅으로는 orm, transaction, hikari 등의 액션을 정확히 보기 힘들어 해당 로그를 Trace 레벨까지 찍어두도록 합니다. 
    - 참고: https://github.com/inbonk/exception-handling-in-nested-transactional-classes/blob/master/src/main/resources/application.yml

## 주의 사항
- 아... logback-spring.xml에서 application.yml 정보 읽어오는 방법을 몰라서 한참 걸렸네요. 아래와 같이 쓰면 됩니다. 
```xml
<springProfile name="slack-paid-logging">
    <springProperty name="devPaidSlackUri" source="logging.slack.webhook-uri-dev-paid" />
    <appender name="DEV_PAID_USER_SLACK_NOTI" class="com.github.maricn.logback.SlackAppender">
        <webhookUri>${devPaidSlackUri}</webhookUri>
        <layout class="ch.qos.logback.classic.PatternLayout">
            <pattern>[ALARM]%d{yyyy-MM-dd HH:mm:ss.SSS} : %msg%n</pattern>
        </layout>
    </appender>

    <appender name="DEV_ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
        <appender-ref ref="DEV_PAID_USER_SLACK_NOTI"/>
        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
            <level>INFO</level>
        </filter>
    </appender>
</springProfile>
```

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
