### PR TITLE
refactor: user details 수정

### DIFF
--- a/src/main/java/com/backend/connectable/order/service/OrderService.java
+++ b/src/main/java/com/backend/connectable/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.backend.connectable.order.service;
 
 import com.backend.connectable.event.domain.Ticket;
 import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.order.domain.Order;
 import com.backend.connectable.order.domain.OrderDetail;
 import com.backend.connectable.order.domain.OrderStatus;
@@ -13,7 +15,9 @@ import com.backend.connectable.order.ui.dto.OrderRequest;
 import com.backend.connectable.order.ui.dto.OrderResponse;
 import com.backend.connectable.security.ConnectableUserDetails;
 import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,24 +29,30 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class OrderService {
 
+    private final UserRepository userRepository;
     private final OrderRepository orderRepository;
     private final TicketRepository ticketRepository;
 
     @Transactional
     public OrderResponse createOrder(ConnectableUserDetails userDetails, OrderRequest orderRequest) {
-        User user = userDetails.getUser();
+        User user = findUser(userDetails.getKlaytnAddress());
         Order order = generateOrder(user, orderRequest);
         orderRepository.save(order);
         return OrderResponse.from("success");
     }
 
     public List<OrderDetailResponse> getOrderDetailList(ConnectableUserDetails userDetails) {
-        String klaytnAddress = userDetails.getUser().getKlaytnAddress();
+        String klaytnAddress = userDetails.getKlaytnAddress();
         List<TicketOrderDetail> orderDetailResponses = orderRepository.getOrderDetailList(klaytnAddress);
 
         return orderDetailResponses.stream()
             .map(OrderMapper.INSTANCE::ticketOrderDetailToResponse)
             .collect(Collectors.toList());
+    }
+
+    private User findUser(String klaytnAddress) {
+        return userRepository.findByKlaytnAddress(klaytnAddress)
+            .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.USER_NOT_FOUND));
     }
 
     private Order generateOrder(User user, OrderRequest orderRequest) {

--- a/src/main/java/com/backend/connectable/security/ConnectableUserDetails.java
+++ b/src/main/java/com/backend/connectable/security/ConnectableUserDetails.java
@@ -1,6 +1,5 @@
 package com.backend.connectable.security;
 
-import com.backend.connectable.user.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -12,7 +11,7 @@ import java.util.Collection;
 @Getter
 public class ConnectableUserDetails implements UserDetails {
 
-    private final User user;
+    private final String klaytnAddress;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -21,17 +20,17 @@ public class ConnectableUserDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return "";
     }
 
     @Override
     public String getUsername() {
-        return user.getNickname();
+        return "";
     }
 
     @Override
     public boolean isAccountNonExpired() {
-        return user.isActive();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
+++ b/src/main/java/com/backend/connectable/security/CustomUserDetailsService.java
@@ -1,27 +1,15 @@
 package com.backend.connectable.security;
 
-import com.backend.connectable.exception.ConnectableException;
-import com.backend.connectable.exception.ErrorType;
-import com.backend.connectable.user.domain.User;
-import com.backend.connectable.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
-
     @Override
-    public UserDetails loadUserByUsername(String klaytnAddress) throws UsernameNotFoundException {
-        Optional<User> optionalUser = userRepository.findByKlaytnAddress(klaytnAddress);
-        return optionalUser.map(ConnectableUserDetails::new)
-                .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.USER_NOT_FOUND));
+    public UserDetails loadUserByUsername(String klaytnAddress) {
+        return new ConnectableUserDetails(klaytnAddress);
     }
 }

--- a/src/main/java/com/backend/connectable/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/connectable/security/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package com.backend.connectable.security;
 
+import com.backend.connectable.security.exception.ConnectableSecurityException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -27,13 +29,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         log.info("[[Token]] : " + token);
         log.info("[[Path]] : " + path);
-        if (!Objects.isNull(token)) {
-            verifyTokenAccordingToPath(token, path);
+        try {
+            if (!Objects.isNull(token)) {
+                verifyTokenAccordingToPath(token, path);
+            }
+            filterChain.doFilter(request, response);
+        } catch (ConnectableSecurityException e) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(e.getMessage());
         }
-        filterChain.doFilter(request, response);
     }
 
-    private void verifyTokenAccordingToPath(String token, String path) {
+    private void verifyTokenAccordingToPath(String token, String path) throws ConnectableSecurityException {
         if (path.startsWith("/admin")) {
             jwtProvider.verifyAdmin(token);
             return;

--- a/src/main/java/com/backend/connectable/security/JwtProvider.java
+++ b/src/main/java/com/backend/connectable/security/JwtProvider.java
@@ -67,7 +67,8 @@ public class JwtProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(exportClaim(token));
+        String klaytnAddress = exportClaim(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(klaytnAddress);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 

--- a/src/main/java/com/backend/connectable/security/SecurityConfiguration.java
+++ b/src/main/java/com/backend/connectable/security/SecurityConfiguration.java
@@ -19,15 +19,15 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.httpBasic().disable()
-            .csrf().disable()
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
-            .authorizeRequests()
-            .antMatchers(HttpMethod.OPTIONS, "/**/*").permitAll()
-            .antMatchers("/users/login", "/events", "/events/**").permitAll()
-            .antMatchers("/users", "/users/tickets", "/orders", "/orders/**").authenticated()
-            .anyRequest().permitAll()
+                .authorizeRequests()
+                .antMatchers(HttpMethod.OPTIONS, "/**/*").permitAll()
+                .antMatchers("/users/login", "/events", "/events/**").permitAll()
+                .antMatchers("/users", "/users/tickets", "/orders", "/orders/**").authenticated()
+                .anyRequest().permitAll()
             .and()
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/backend/connectable/security/exception/ConnectableSecurityException.java
+++ b/src/main/java/com/backend/connectable/security/exception/ConnectableSecurityException.java
@@ -1,0 +1,27 @@
+package com.backend.connectable.security.exception;
+
+import com.backend.connectable.exception.ErrorType;
+import com.backend.connectable.exception.ExceptionResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ConnectableSecurityException extends Exception {
+
+    private static final ObjectMapper JSON_CONVERTER = new ObjectMapper();
+
+    public ConnectableSecurityException(String message) {
+        super(message);
+    }
+
+    public ConnectableSecurityException(ErrorType errorType) {
+        this(generateExceptionMessage(errorType));
+    }
+
+    private static String generateExceptionMessage(ErrorType errorType) {
+        try {
+            return JSON_CONVERTER.writeValueAsString(new ExceptionResponse(errorType.getErrorCode(), errorType.getMessage()));
+        } catch (JsonProcessingException e) {
+            return "JWT 인증 오류";
+        }
+    }
+}

--- a/src/main/java/com/backend/connectable/user/domain/User.java
+++ b/src/main/java/com/backend/connectable/user/domain/User.java
@@ -47,6 +47,11 @@ public class User {
         return !Objects.isNull(phoneNumber);
     }
 
+    public void modifyInformation(String nickname, String phoneNumber) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryCustom.java
@@ -3,6 +3,4 @@ package com.backend.connectable.user.domain.repository;
 public interface UserRepositoryCustom {
 
     void deleteUser(String klaytnAddress);
-
-    void modifyUser(String klaytnAddress, String nickname, String phoneNumber);
 }

--- a/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/user/domain/repository/UserRepositoryImpl.java
@@ -23,13 +23,4 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             .where(user.klaytnAddress.eq(klaytnAddress))
             .execute();
     }
-
-    public void modifyUser(String klaytnAddress, String nickname, String phoneNumber) {
-        queryFactory
-            .update(user)
-            .set(user.nickname, nickname)
-            .set(user.phoneNumber, phoneNumber)
-            .where(user.klaytnAddress.eq(klaytnAddress))
-            .execute();
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   profiles:
     active: local
     group:
+      local: console-logging
       dev: console-logging,file-sql-logging,file-info-logging,file-error-logging,slack-dev-error-logging,slack-paid-logging
 ---
 spring:

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -185,7 +185,7 @@ class OrderServiceTest {
     @Test
     void createOrder() {
         // given
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user.getKlaytnAddress());
         OrderRequest orderRequest = new OrderRequest("이정필", "010-3333-7777",
             Arrays.asList(ticket1.getId(), ticket2.getId()), 30000);
 
@@ -204,7 +204,7 @@ class OrderServiceTest {
     @Test
     void getOrderDetailList() {
         // given
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user.getKlaytnAddress());
         OrderRequest orderRequest1 = new OrderRequest("이정필", "010-3333-7777",
             Arrays.asList(ticket1.getId(), ticket2.getId()), 200000);
         OrderRequest orderRequest2 = new OrderRequest("이정필", "010-3333-7777",

--- a/src/test/java/com/backend/connectable/security/JwtProviderTest.java
+++ b/src/test/java/com/backend/connectable/security/JwtProviderTest.java
@@ -1,6 +1,6 @@
 package com.backend.connectable.security;
 
-import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.security.exception.ConnectableSecurityException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,12 +52,12 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.verify(token))
-                .isInstanceOf(ConnectableException.class);
+                .isInstanceOf(ConnectableSecurityException.class);
     }
 
     @Test
     @DisplayName("생성된 jwt 토큰의 페이로드를 추출할 수 있다.")
-    void exportClaim() {
+    void exportClaim() throws ConnectableSecurityException {
         // given
         String claim = "0x1234abcd";
         String token = jwtProvider.generateToken(claim);
@@ -77,7 +77,7 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.exportClaim(invalidToken))
-            .isInstanceOf(ConnectableException.class);
+            .isInstanceOf(ConnectableSecurityException.class);
     }
 
     @DisplayName("어드민 JWT 토큰에 대해 verify 할 수 있다.")
@@ -99,6 +99,6 @@ class JwtProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtProvider.verifyAdmin(adminToken))
-            .isInstanceOf(ConnectableException.class);
+            .isInstanceOf(ConnectableSecurityException.class);
     }
 }

--- a/src/test/java/com/backend/connectable/security/exception/ConnectableSecurityExceptionTest.java
+++ b/src/test/java/com/backend/connectable/security/exception/ConnectableSecurityExceptionTest.java
@@ -1,0 +1,25 @@
+package com.backend.connectable.security.exception;
+
+import com.backend.connectable.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class ConnectableSecurityExceptionTest {
+
+    @DisplayName("ErrorType을 에러메시지 JSON 형식으로 변환할 수 있다.")
+    @Test
+    void createException() {
+        // given & when
+        ConnectableSecurityException connectableSecurityException = new ConnectableSecurityException(ErrorType.INVALID_TOKEN);
+
+        // then
+        String expectedMessage =
+            "{" +
+                "\"errorCode\":\"" + ErrorType.INVALID_TOKEN.getErrorCode() + "\"," +
+                "\"message\":\"" + ErrorType.INVALID_TOKEN.getMessage() + "\"" +
+            "}";
+        assertThat(connectableSecurityException.getMessage()).isEqualTo(expectedMessage);
+    }
+}

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -162,7 +162,7 @@ class UserServiceTest {
     @Test
     void getUserByUserDetails() {
         // given
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1.getKlaytnAddress());
 
         // when
         UserResponse userResponse = userService.getUserByUserDetails(connectableUserDetails);
@@ -178,7 +178,7 @@ class UserServiceTest {
     @Test
     void deleteUser() {
         // given
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1.getKlaytnAddress());
 
         // when
         UserModifyResponse userModifyResponse = userService.deleteUserByUserDetails(connectableUserDetails);
@@ -191,7 +191,7 @@ class UserServiceTest {
     @Test
     void modifyUser() {
         // given
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1.getKlaytnAddress());
         UserModifyRequest userModifyRequest = new UserModifyRequest("mrlee7", "01085161399");
 
         // when
@@ -290,7 +290,7 @@ class UserServiceTest {
     void getUserTicketsByUserDetails() {
         // given
         given(eventService.findTicketByUserAddress(user1KlaytnAddress)).willReturn(Arrays.asList(ticket1, ticket2));
-        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1);
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails(user1.getKlaytnAddress());
 
         // when
         UserTicketListResponse userTicketListResponse = userService.getUserTicketsByUserDetails(connectableUserDetails);


### PR DESCRIPTION
## 작업 내용
1. **UserDetails가 klaytnAddress만을 들고 있도록 리팩터링**
  - 오전에 설명했던 것 처럼, Spring Security에서 UserDetails에 User 엔티티를 담아봤자 Spring MVC에 도착하고 나서는 영속성 컨텍스트의 혜택을 받지 못해요. 
    - 이유는 Filter 단에서 User 엔티티 정보를 가져와 영속성 컨텍스트에 영속화 시켜놨더니만,,,
    - 정작 Open Session In View는 Spring MVC의 Interceptor 부터 열리기 시작해서 (새로운 엔티티 매니저 오픈!)
    - 기존에 Spring Security의 SecurityContext에 넣어뒀던 UserDetails의 경우, **준영속** 상태에 빠지게 되고 
    - 그에 따라, 준영속 상태가 되버린 User 엔티티로는 영속성 컨텍스트의 혜택을 받지못하는데, 여기서 혜택은 1차캐시, 변경 감지를 뜻하고
    - 따라서 준영속 상태의 User 엔티티로는 기존의 modify 도메인 로직의 변경 감지가 안먹혔던 겁니다. 🥲
  - 따라서 UserDetails는 klaytnAddress만을 들고 있게 변경하였고, Service단에 들어와서 다시 User를 조회하여 영속성 컨텍스트의 혜택을 받을 수 있도록! JPA를 JPA 처럼 쓸 수 있도록 리팩터링 했습니다. 
    - 없앴던 User 정보 변경해주는 도메인 로직도 부활시켰습니다. 

2. **Spring Security에서의 예외처리**
  - 삽질 좀 했습니다. 주의 사항에 삽질 과정 적어두겠습니다. 
  - 현재 구현은 다음과 같이 이뤄집니다. 
  - security.exception 패키지 하위에 ConnectableSecurityException을 정의합니다. 
    - 해당 예외는 CheckedException 입니다. 
    - 이를 CheckedException으로 구현한 이유는, 해당 에러가 어디에서 터지는지, 명시적으로 관리해주는 것이 안전하다고 판단했기 때문입니다. 
    - Spring Security에서는 ControllerAdvice 처럼 전역적으로 예외를 잡아주는 방법이 없습니다. (정확히는 이런 방식을 주의사항에서 시도했으나 실패,,,)
    - 그냥 명시적으로 try-catch 방식을 통해 JwtAuthenticationFilter 에서 잡아주는 것이 현재의 최선이라고 판단하여 CheckedException으로, 예외 발생의 경로를 추적할 수 있도록 구현하였습니다. 
  - JwtAuthenticationFilter 에서 try-catch를 통해 try 문에서 예외가 없다면 필터를 마저 태우고, 예외가 발생한다면 response에 403 에러를 띄워 보내줍니다. 
    - 기존의 예외 컨벤션에 맞추기 위해 ConnectableSecurityException에는 ObjectMapper를 넣어뒀습니다

## 주의 사항
- 영속성 컨텍스트 vs 엔티티 매니저 vs 엔티티 매니저 팩토리
   - JPA를 배울때 초장부터 나오는 내용인데 설명할 수 있냐하면 못할 것 같은데요? 같이 알아보시죠.  

- 아... 스프링 시큐리티 예외처리 국룰은 아래와 같은 방식인 것 같은데...
  - 참고 블로그 : https://blog.naver.com/PostView.nhn?blogId=qjawnswkd&logNo=222303477758
  - 내 TIL : https://github.com/joelonsw/TIL/blob/master/concepts/Spring%20Security.md#spring-security-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC

- 이렇게 하려고 삽질을 좀 했는데,,, 실패했네요
  - 우선 AccessDeniedException, AuthenticationException을 커스텀으로 정의해서 잘 쓰지 않는 것 같고...
  - 해당 exception을 상속받아 커스텀 예외를 정의한 뒤, JwtProvider에서 throw를 해줬으나 jwtAccessDeniedHandler에서 잡지 못했고...
  - 결국 현재 PR과 같이 CheckedException으로 ConnectableSecurityException을 정의하여 try-catch문으로 filter단에서 잡도록 구현했네요. 
  - Spring Security에서의 예외처리를 조금 더 잘 알아야할 것 같습니다. 일단은 급한대로 JwtAuthenticationFilter에서 예외처리하도록 구현했습니다. 🥲

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
