### PR TITLE
refactor: 정책에 따라 fetchType 명시 제거

### DIFF
--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -23,7 +23,7 @@ public class OrderDetail extends BaseEntity {
     @Column(nullable = true)
     private String txHash;
 
-    @OneToOne(fetch = FetchType.EAGER)
+    @OneToOne
     private Ticket ticket;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 작업 내용
- @XToOne을 LAZY로 사용하는 경우, @XToMany를 EAGER로 사용하는 경우에만 명시하기로 내부 정책 정함.

## 주의 사항

## PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
