### PR TITLE
feat: flyway 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 
     // Slack
     implementation 'com.github.maricn:logback-slack-appender:1.6.1'
+
+    // flyway
+    implementation('org.flywaydb:flyway-core:6.4.2')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/connectable/DataLoader.java
+++ b/src/main/java/com/backend/connectable/DataLoader.java
@@ -84,7 +84,6 @@ public class DataLoader implements ApplicationRunner {
             TicketMetadata ticketMetadata = s3Service.fetchMetadata(tokenUri)
                 .toTicketMetadata();
             Ticket brownTicket = Ticket.builder()
-                .user(admin)
                 .event(brownEvent)
                 .tokenUri(tokenUri)
                 .tokenId(i)

--- a/src/main/java/com/backend/connectable/exception/ErrorType.java
+++ b/src/main/java/com/backend/connectable/exception/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
     TICKET_TO_ON_SALE_UNAVAILABLE("TICKET-004", "PENDING 상태만 ON_SALE로 변할 수 있습니다."),
     TICKET_METADATA_TO_JSON_FAILURE("TICKET-005", "티켓 메타데이터를 JSON으로 변환하는데 실패했습니다"),
     TICKET_JSON_TO_METADATA_FAILURE("TICKET-006", "JSON을 티켓 메타데이터로 변환하는데 실패했습니다"),
+    TICKET_ALREADY_USED("TICKET-007", "이미 입장에 사용된 티켓입니다"),
 
     ORDER_TO_PAID_UNAVAILABLE("ORDER-001", "PAID 상태로 변경이 불가합니다."),
     ORDER_TO_UNPAID_UNAVAILABLE("ORDER-002", "UNPAID 상태로 변경이 불가합니다."),

--- a/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
+++ b/src/main/java/com/backend/connectable/order/domain/OrderDetail.java
@@ -67,7 +67,7 @@ public class OrderDetail extends BaseEntity {
     public void transferSuccess(String txHash) {
         this.orderStatus = orderStatus.toTransferSuccess();
         this.txHash = txHash;
-        this.ticket.transferredTo(order.getUser());
+        this.ticket.soldOut();
     }
 
     public void transferFail() {

--- a/src/main/java/com/backend/connectable/user/ui/dto/UserResponse.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserResponse.java
@@ -1,7 +1,6 @@
 package com.backend.connectable.user.ui.dto;
 
 import com.backend.connectable.user.domain.User;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,8 @@ spring:
     url: jdbc:h2:mem:connectable
     username: sa
     password:
+  flyway:
+    enabled: false
 jwt:
   secret: uacc-to-the-moon
   expire-time: 14400000
@@ -68,6 +70,9 @@ spring:
     url: ${jdbc.url}
     username: ${jdbc.username}
     password: ${jdbc.password}
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 aws:
   paramstore:
     enabled: true
@@ -129,6 +134,9 @@ spring:
     url: ${jdbc.url}
     username: ${jdbc.username}
     password: ${jdbc.password}
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 aws:
   paramstore:
     enabled: true

--- a/src/main/resources/db/migration/V1_1__init_constraints.sql
+++ b/src/main/resources/db/migration/V1_1__init_constraints.sql
@@ -1,0 +1,29 @@
+alter table orders
+    add constraint fk_orders_to_user
+        foreign key (user_id)
+            references user(id);
+
+alter table event
+    add constraint fk_event_to_artist
+        foreign key (artist_id)
+            references artist(id);
+
+alter table ticket
+    add constraint fk_ticket_to_event
+        foreign key (event_id)
+            references event(id);
+
+alter table ticket
+    add constraint fk_ticket_to_user
+        foreign key (user_id)
+            references user(id);
+
+alter table order_detail
+    add constraint fk_order_detail_to_orders
+        foreign key (order_id)
+            references orders(id);
+
+alter table order_detail
+    add constraint fk_order_detail_to_ticket
+        foreign key (ticket_id)
+            references ticket(id);

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,85 @@
+CREATE TABLE `artist` (
+                          `id` bigint NOT NULL AUTO_INCREMENT,
+                          `artist_image` varchar(255) DEFAULT NULL,
+                          `artist_name` varchar(255) DEFAULT NULL,
+                          `bank_account` varchar(255) DEFAULT NULL,
+                          `bank_company` varchar(255) DEFAULT NULL,
+                          `email` varchar(255) DEFAULT NULL,
+                          `password` varchar(255) DEFAULT NULL,
+                          `phone_number` varchar(255) DEFAULT NULL,
+                          PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `user` (
+                        `id` bigint NOT NULL AUTO_INCREMENT,
+                        `is_active` bit(1) NOT NULL,
+                        `klaytn_address` varchar(255) DEFAULT NULL,
+                        `nickname` varchar(255) DEFAULT NULL,
+                        `phone_number` varchar(255) DEFAULT NULL,
+                        `privacy_agreement` bit(1) NOT NULL,
+                        PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+                          `id` bigint NOT NULL AUTO_INCREMENT,
+                          `created_date` datetime(6) NOT NULL,
+                          `modified_date` datetime(6) NOT NULL,
+                          `orderer_name` varchar(255) DEFAULT NULL,
+                          `orderer_phone_number` varchar(255) DEFAULT NULL,
+                          `user_id` bigint NOT NULL,
+                          PRIMARY KEY (`id`),
+                          KEY `FKel9kyl84ego2otj2accfd8mr7` (`user_id`),
+                          CONSTRAINT `FKel9kyl84ego2otj2accfd8mr7` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `event` (
+                         `id` bigint NOT NULL AUTO_INCREMENT,
+                         `contract_address` varchar(255) DEFAULT NULL,
+                         `description` longtext NOT NULL,
+                         `end_time` datetime(6) DEFAULT NULL,
+                         `event_image` varchar(255) DEFAULT NULL,
+                         `event_name` varchar(255) DEFAULT NULL,
+                         `event_sales_option` varchar(255) DEFAULT NULL,
+                         `instagram_url` varchar(255) DEFAULT NULL,
+                         `location` varchar(255) DEFAULT NULL,
+                         `sales_from` datetime(6) DEFAULT NULL,
+                         `sales_to` datetime(6) DEFAULT NULL,
+                         `start_time` datetime(6) DEFAULT NULL,
+                         `twitter_url` varchar(255) DEFAULT NULL,
+                         `webpage_url` varchar(255) DEFAULT NULL,
+                         `artist_id` bigint NOT NULL,
+                         PRIMARY KEY (`id`),
+                         KEY `FKdvvkbxm5gn0f66no9ja48hks2` (`artist_id`),
+                         CONSTRAINT `FKdvvkbxm5gn0f66no9ja48hks2` FOREIGN KEY (`artist_id`) REFERENCES `artist` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `ticket` (
+                          `id` bigint NOT NULL AUTO_INCREMENT,
+                          `price` int NOT NULL,
+                          `ticket_metadata` text,
+                          `ticket_sales_status` varchar(255) DEFAULT NULL,
+                          `token_id` int NOT NULL,
+                          `token_uri` varchar(255) DEFAULT NULL,
+                          `event_id` bigint NOT NULL,
+                          `user_id` bigint NOT NULL,
+                          PRIMARY KEY (`id`),
+                          KEY `FKfytuhjopeamxbt1cpudy92x5n` (`event_id`),
+                          KEY `FKdvt57mcco3ogsosi97odw563o` (`user_id`),
+                          CONSTRAINT `FKdvt57mcco3ogsosi97odw563o` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+                          CONSTRAINT `FKfytuhjopeamxbt1cpudy92x5n` FOREIGN KEY (`event_id`) REFERENCES `event` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `order_detail` (
+                                `id` bigint NOT NULL AUTO_INCREMENT,
+                                `created_date` datetime(6) NOT NULL,
+                                `modified_date` datetime(6) NOT NULL,
+                                `order_status` varchar(255) DEFAULT NULL,
+                                `tx_hash` varchar(255) DEFAULT NULL,
+                                `order_id` bigint NOT NULL,
+                                `ticket_id` bigint DEFAULT NULL,
+                                PRIMARY KEY (`id`),
+                                KEY `FKrws2q0si6oyd6il8gqe2aennc` (`order_id`),
+                                KEY `FKrre8eo0thwbk3a83648x1o0ep` (`ticket_id`),
+                                CONSTRAINT `FKrre8eo0thwbk3a83648x1o0ep` FOREIGN KEY (`ticket_id`) REFERENCES `ticket` (`id`),
+                                CONSTRAINT `FKrws2q0si6oyd6il8gqe2aennc` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -27,9 +27,7 @@ CREATE TABLE `orders` (
                           `orderer_name` varchar(255) DEFAULT NULL,
                           `orderer_phone_number` varchar(255) DEFAULT NULL,
                           `user_id` bigint NOT NULL,
-                          PRIMARY KEY (`id`),
-                          KEY `FKel9kyl84ego2otj2accfd8mr7` (`user_id`),
-                          CONSTRAINT `FKel9kyl84ego2otj2accfd8mr7` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+                          PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `event` (
@@ -48,9 +46,7 @@ CREATE TABLE `event` (
                          `twitter_url` varchar(255) DEFAULT NULL,
                          `webpage_url` varchar(255) DEFAULT NULL,
                          `artist_id` bigint NOT NULL,
-                         PRIMARY KEY (`id`),
-                         KEY `FKdvvkbxm5gn0f66no9ja48hks2` (`artist_id`),
-                         CONSTRAINT `FKdvvkbxm5gn0f66no9ja48hks2` FOREIGN KEY (`artist_id`) REFERENCES `artist` (`id`)
+                         PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `ticket` (
@@ -62,11 +58,7 @@ CREATE TABLE `ticket` (
                           `token_uri` varchar(255) DEFAULT NULL,
                           `event_id` bigint NOT NULL,
                           `user_id` bigint NOT NULL,
-                          PRIMARY KEY (`id`),
-                          KEY `FKfytuhjopeamxbt1cpudy92x5n` (`event_id`),
-                          KEY `FKdvt57mcco3ogsosi97odw563o` (`user_id`),
-                          CONSTRAINT `FKdvt57mcco3ogsosi97odw563o` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
-                          CONSTRAINT `FKfytuhjopeamxbt1cpudy92x5n` FOREIGN KEY (`event_id`) REFERENCES `event` (`id`)
+                          PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `order_detail` (
@@ -77,9 +69,5 @@ CREATE TABLE `order_detail` (
                                 `tx_hash` varchar(255) DEFAULT NULL,
                                 `order_id` bigint NOT NULL,
                                 `ticket_id` bigint DEFAULT NULL,
-                                PRIMARY KEY (`id`),
-                                KEY `FKrws2q0si6oyd6il8gqe2aennc` (`order_id`),
-                                KEY `FKrre8eo0thwbk3a83648x1o0ep` (`ticket_id`),
-                                CONSTRAINT `FKrre8eo0thwbk3a83648x1o0ep` FOREIGN KEY (`ticket_id`) REFERENCES `ticket` (`id`),
-                                CONSTRAINT `FKrws2q0si6oyd6il8gqe2aennc` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`)
+                                PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V2__add_ticket_is_used.sql
+++ b/src/main/resources/db/migration/V2__add_ticket_is_used.sql
@@ -1,0 +1,1 @@
+alter table ticket add column is_used bit(1) default 0;

--- a/src/main/resources/db/migration/V3__remove_ticket_user_mapping.sql
+++ b/src/main/resources/db/migration/V3__remove_ticket_user_mapping.sql
@@ -1,0 +1,3 @@
+alter table ticket drop foreign key FKdvt57mcco3ogsosi97odw563o;
+
+alter table ticket drop user_id;

--- a/src/main/resources/db/migration/V3__remove_ticket_user_mapping.sql
+++ b/src/main/resources/db/migration/V3__remove_ticket_user_mapping.sql
@@ -1,3 +1,3 @@
-alter table ticket drop foreign key FKdvt57mcco3ogsosi97odw563o;
+alter table ticket drop foreign key `fk_ticket_to_user`;
 
 alter table ticket drop user_id;

--- a/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
@@ -113,7 +113,6 @@ class AdminServiceTest {
         .build();
 
     Ticket joelTicket4 = Ticket.builder()
-        .user(admin)
         .event(joelEvent)
         .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/4.json")
         .tokenId(4)
@@ -134,7 +133,6 @@ class AdminServiceTest {
         .build();
 
     Ticket joelTicket5 = Ticket.builder()
-        .user(admin)
         .event(joelEvent)
         .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/5.json")
         .tokenId(5)
@@ -183,7 +181,6 @@ class AdminServiceTest {
         OrderDetail resultOrderDetail = orderDetailRepository.findById(orderDetailId).get();
         assertThat(resultOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.TRANSFER_SUCCESS);
         assertThat(resultOrderDetail.getTxHash()).isEqualTo("0x1234abcd");
-        assertThat(resultOrderDetail.getTicket().getUser().getId()).isEqualTo(joel.getId());
         assertThat(resultOrderDetail.getTicket().getTicketSalesStatus()).isEqualTo(TicketSalesStatus.SOLD_OUT);
     }
 

--- a/src/test/java/com/backend/connectable/event/domain/TicketTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/TicketTest.java
@@ -1,0 +1,55 @@
+package com.backend.connectable.event.domain;
+
+import com.backend.connectable.exception.ConnectableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+class TicketTest {
+
+    @DisplayName("새로 생성한 티켓은 isUsed가 false이다.")
+    @Test
+    void isUsedFalseWhenCreated() {
+        // given
+        Ticket ticket = Ticket.builder()
+            .tokenId(1)
+            .tokenUri("tokenUri")
+            .price(10000)
+            .build();
+
+        // when & then
+        assertThat(ticket.isUsed()).isFalse();
+    }
+
+    @DisplayName("티켓의 isUsed가 false여야 사용할 수 있다.")
+    @Test
+    void useTicket() {
+        // given
+        Ticket ticket = Ticket.builder()
+            .tokenId(1)
+            .tokenUri("tokenUri")
+            .price(10000)
+            .build();
+
+        // when & then
+        assertThatCode(ticket::useToEnterEvent).doesNotThrowAnyException();
+    }
+
+    @DisplayName("티켓의 isUsed가 true라면 재입장에 사용할 수 있다.")
+    @Test
+    void usedTicketCannotBeReused() {
+        // given
+        Ticket ticket = Ticket.builder()
+            .tokenId(1)
+            .tokenUri("tokenUri")
+            .price(10000)
+            .build();
+        ticket.useToEnterEvent();
+
+        // when & then
+        assertThatCode(ticket::useToEnterEvent)
+            .isInstanceOf(ConnectableException.class);
+    }
+}

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -114,7 +114,6 @@ class EventRepositoryTest {
     void findAllTickets() {
         // given
         Ticket ticket1SoldOut = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(1)
             .tokenUri("https://token1.uri")
@@ -123,7 +122,6 @@ class EventRepositoryTest {
             .build();
 
         Ticket ticket2SoldOut = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(2)
             .tokenUri("https://token1.uri")
@@ -132,7 +130,6 @@ class EventRepositoryTest {
             .build();
 
         Ticket ticket3Pending = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(3)
             .tokenUri("https://token1.uri")
@@ -141,7 +138,6 @@ class EventRepositoryTest {
             .build();
 
         Ticket ticket4Pending = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(4)
             .tokenUri("https://token1.uri")
@@ -150,7 +146,6 @@ class EventRepositoryTest {
             .build();
 
         Ticket ticket5OnSale = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(5)
             .tokenUri("https://token1.uri")
@@ -160,7 +155,6 @@ class EventRepositoryTest {
 
 
         Ticket ticket6OnSale = Ticket.builder()
-            .user(user)
             .event(joelEvent)
             .tokenId(6)
             .tokenUri("https://token1.uri")

--- a/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
@@ -84,7 +84,6 @@ class TicketRepositoryTest {
 
     String tokenUri1 = "https://token.uri.1";
     Ticket joelTicket1 = Ticket.builder()
-            .user(joel)
             .event(joelEvent)
             .tokenUri(tokenUri1)
             .price(100000)
@@ -94,7 +93,6 @@ class TicketRepositoryTest {
 
     String tokenUri2 = "https://token.uri.2";
     Ticket joelTicket2 = Ticket.builder()
-        .user(joel)
         .event(joelEvent)
         .tokenUri(tokenUri2)
         .price(100000)
@@ -116,7 +114,6 @@ class TicketRepositoryTest {
         Ticket savedTicket = ticketRepository.save(joelTicket1);
 
         // then
-        assertThat(savedTicket.getUser()).isEqualTo(joel);
         assertThat(savedTicket.getEvent()).isEqualTo(joelEvent);
         assertThat(savedTicket.getPrice()).isEqualTo(100000);
         assertThat(savedTicket.getTicketSalesStatus()).isEqualTo(TicketSalesStatus.ON_SALE);

--- a/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
+++ b/src/test/java/com/backend/connectable/order/service/OrderServiceTest.java
@@ -127,7 +127,6 @@ class OrderServiceTest {
             .build();
 
         ticket1 = Ticket.builder()
-            .user(user)
             .event(event)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
             .price(100000)
@@ -147,7 +146,6 @@ class OrderServiceTest {
             .build();
 
         ticket2 = Ticket.builder()
-            .user(user)
             .event(event)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
             .price(100000)
@@ -167,7 +165,6 @@ class OrderServiceTest {
             .build();
 
         ticket3 = Ticket.builder()
-            .user(user)
             .event(event)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/3.json")
             .price(100000)

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -124,7 +124,6 @@ class UserServiceTest {
             .build();
 
         ticket1 = Ticket.builder()
-            .user(user1)
             .event(event1)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json")
             .price(100000)
@@ -144,7 +143,6 @@ class UserServiceTest {
             .build();
 
         ticket2 = Ticket.builder()
-            .user(user1)
             .event(event1)
             .tokenUri("https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json")
             .price(100000)


### PR DESCRIPTION
## 작업 내용
1. **Flyway를 도입합니다**
    - DB 형상관리를 위해 Flyway를 도입합니다. 
    - 현재 dev 서버에 있는 내용을 스냅샷으로 복사해 새로운 rds를 만든 후 테스트를 진행하고, 성공적으로 스키마가 변경되었습니다. 

2. **Ticket에 isUsed 필드를 추가합니다**
    - NFT와 1:1 매핑되는 Ticket 엔티티에 isUsed 필드를 추가합니다. 
    - 해당 필드로 입장관리를 할 예정입니다 

3. **Ticket과 User의 연관관계를 끊습니다**
    - 연관이 없어진 두 엔티티의 연관관계를 끊어뒀습니다. 

## 주의 사항
- 이제 ddl-auto 전략을 prod/dev 모두 none => validate로 바꾸는 것이 좋아보입니다!

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
