### PR TITLE
refactor: TicketResponse isUsed 필드 추가

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
@@ -23,12 +23,15 @@ public class EventTicket {
     private TicketSalesStatus ticketSalesStatus;
     private int tokenId;
     private String tokenUri;
+    private boolean isUsed;
     @Convert(converter = TicketMetadata.class)
     private TicketMetadata metadata;
     private String contractAddress;
 
     @QueryProjection
-    public EventTicket(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, TicketSalesStatus ticketSalesStatus, int tokenId, String tokenUri, TicketMetadata metadata, String contractAddress) {
+    public EventTicket(Long id, int price, String artistName, LocalDateTime eventDate, String eventName,
+                       TicketSalesStatus ticketSalesStatus, int tokenId, String tokenUri, boolean isUsed,
+                       TicketMetadata metadata, String contractAddress) {
         this.id = id;
         this.price = price;
         this.artistName = artistName;
@@ -37,6 +40,7 @@ public class EventTicket {
         this.ticketSalesStatus = ticketSalesStatus;
         this.tokenId = tokenId;
         this.tokenUri = tokenUri;
+        this.isUsed = isUsed;
         this.metadata = metadata;
         this.contractAddress = contractAddress;
     }

--- a/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventTicket.java
@@ -44,4 +44,12 @@ public class EventTicket {
         this.metadata = metadata;
         this.contractAddress = contractAddress;
     }
+
+    public boolean getIsUsed() {
+        return isUsed;
+    }
+
+    public boolean isUsed() {
+        return isUsed;
+    }
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -79,6 +79,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             ticket.ticketSalesStatus,
             ticket.tokenId,
             ticket.tokenUri,
+            ticket.isUsed,
             ticket.ticketMetadata,
             event.contractAddress.as("contractAddress")
             ))
@@ -104,6 +105,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             ticket.ticketSalesStatus,
             ticket.tokenId,
             ticket.tokenUri,
+            ticket.isUsed,
             ticket.ticketMetadata,
             event.contractAddress
             ))

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -77,6 +77,7 @@ public class EventService {
             .ticketSalesStatus(eventTicket.getTicketSalesStatus())
             .tokenId(eventTicket.getTokenId())
             .tokenUri(eventTicket.getTokenUri())
+            .isUsed(eventTicket.isUsed())
             .metadata(eventTicket.getMetadata())
             .contractAddress(eventTicket.getContractAddress())
             .ownedBy(tokenResponse.getOwner())

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
@@ -24,7 +24,6 @@ public class TicketResponse {
     private boolean isUsed;
     private TicketMetadataResponse metadata;
     private String contractAddress;
-
     private String ownedBy;
 
     @Builder

--- a/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/TicketResponse.java
@@ -21,6 +21,7 @@ public class TicketResponse {
     private TicketSalesStatus ticketSalesStatus;
     private int tokenId;
     private String tokenUri;
+    private boolean isUsed;
     private TicketMetadataResponse metadata;
     private String contractAddress;
 
@@ -28,7 +29,7 @@ public class TicketResponse {
 
     @Builder
     public TicketResponse(Long id, int price, String artistName, LocalDateTime eventDate, String eventName, TicketSalesStatus ticketSalesStatus,
-                          int tokenId, String tokenUri, TicketMetadata metadata, String contractAddress, String ownedBy) {
+                          int tokenId, String tokenUri, boolean isUsed, TicketMetadata metadata, String contractAddress, String ownedBy) {
         this.id = id;
         this.price = price;
         this.artistName = artistName;
@@ -37,6 +38,7 @@ public class TicketResponse {
         this.ticketSalesStatus = ticketSalesStatus;
         this.tokenId = tokenId;
         this.tokenUri = tokenUri;
+        this.isUsed = isUsed;
         this.metadata = TicketMetadataResponse.of(metadata);
         this.contractAddress = contractAddress;
         this.ownedBy = ownedBy;

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -109,6 +109,7 @@ class EventControllerTest {
         TicketSalesStatus.ON_SALE,
         0,
         "https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/1.json",
+        false,
         SAMPLE_TICKET_METADATA,
         "0x123456",
         "0xabcd"
@@ -123,6 +124,7 @@ class EventControllerTest {
         TicketSalesStatus.ON_SALE,
         1,
         "https://connectable-events.s3.ap-northeast-2.amazonaws.com/json/2.json",
+        false,
         SAMPLE_TICKET_METADATA,
         "0x123456",
         "0xabcd"


### PR DESCRIPTION
## 작업 내용
- TicketResponse dto에 isUsed 필드를 추가합니다
- 이를 통해 사용된 티켓의 경우 입장 QR을 생성하지 않도록 합니다!

## 주의 사항
- EventMapper에 의존적인 Dto 변환로직입니다. isUsed 필드를 getIsUsed() 메서드로 빼줘야 매핑이 되더라고요!

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
