### PR TITLE
refactor: DB에서 ContractName을 가지도록 수정

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/Event.java
+++ b/src/main/java/com/backend/connectable/event/domain/Event.java
@@ -32,6 +32,8 @@ public class Event {
 
     private String contractAddress;
 
+    private String contractName;
+
     private String eventName;
 
     private String location;
@@ -52,8 +54,8 @@ public class Event {
     private EventSalesOption eventSalesOption;
 
     @Builder
-    public Event(Long id, Artist artist, String description, LocalDateTime salesFrom, LocalDateTime salesTo,
-                 String contractAddress, String eventName, String location, String eventImage, String twitterUrl,
+    public Event(Long id, Artist artist, String description, LocalDateTime salesFrom, LocalDateTime salesTo, String contractAddress,
+                 String contractName, String eventName, String location, String eventImage, String twitterUrl,
                  String instagramUrl, String webpageUrl, LocalDateTime startTime, LocalDateTime endTime, EventSalesOption eventSalesOption) {
         this.id = id;
         this.artist = artist;
@@ -61,6 +63,7 @@ public class Event {
         this.salesFrom = salesFrom;
         this.salesTo = salesTo;
         this.contractAddress = contractAddress;
+        this.contractName = contractName;
         this.eventName = eventName;
         this.location = location;
         this.eventImage = eventImage;

--- a/src/main/java/com/backend/connectable/event/domain/dto/EventDetail.java
+++ b/src/main/java/com/backend/connectable/event/domain/dto/EventDetail.java
@@ -21,6 +21,7 @@ public class EventDetail {
     private String artistImage;
     private String description;
     private String contractAddress;
+    private String contractName;
     private LocalDateTime salesFrom;
     private LocalDateTime salesTo;
     private String twitterUrl;

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -44,6 +44,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             event.endTime,
             event.description,
             event.contractAddress,
+            event.contractName,
             event.salesFrom,
             event.salesTo,
             event.twitterUrl,

--- a/src/main/java/com/backend/connectable/event/mapper/EventMapper.java
+++ b/src/main/java/com/backend/connectable/event/mapper/EventMapper.java
@@ -24,5 +24,6 @@ public interface EventMapper {
     @Mapping(target="date", source = "startTime")
     EventResponse eventToResponse(Event event);
 
+    @Mapping(target="ownedBy", ignore = true)
     TicketResponse ticketToResponse(EventTicket eventTicket);
 }

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -47,14 +47,7 @@ public class EventService {
     public EventDetailResponse getEventDetail(Long eventId) {
         EventDetail eventDetail = eventRepository.findEventDetailByEventId(eventId)
             .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.EVENT_NOT_EXISTS));
-        EventDetailResponse eventDetailResponse = EventMapper.INSTANCE.eventDetailToResponse(eventDetail);
-
-        // Todo : Contract Name을 DB에 저장할 것
-        ContractItemResponse eventContractInformation = kasService.getMyContract(eventDetail.getContractAddress());
-        String contractName = eventContractInformation.getName();
-        String openseaUrl = OpenseaCollectionNamingUtil.toOpenseaCollectionUrl(contractName);
-        eventDetailResponse.setOpenseaUrl(openseaUrl);
-        return eventDetailResponse;
+        return EventMapper.INSTANCE.eventDetailToResponse(eventDetail);
     }
 
     public List<TicketResponse> getTicketList(Long eventId) {

--- a/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
+++ b/src/main/java/com/backend/connectable/event/ui/dto/EventDetailResponse.java
@@ -2,6 +2,7 @@ package com.backend.connectable.event.ui.dto;
 
 import com.backend.connectable.event.domain.EventSalesOption;
 import com.backend.connectable.global.common.util.DateTimeUtil;
+import com.backend.connectable.global.common.util.OpenseaCollectionNamingUtil;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,7 @@ public class EventDetailResponse {
     private String artistImage;
     private String description;
     private String contractAddress;
+    private String openseaUrl;
     private Long salesFrom;
     private Long salesTo;
     private String twitterUrl;
@@ -33,11 +35,10 @@ public class EventDetailResponse {
     private int price;
     private String location;
     private EventSalesOption eventSalesOption;
-    private String openseaUrl;
 
     @Builder
     public EventDetailResponse(Long id, String name, String image, String artistName, String artistImage, String description,
-                               String contractAddress, LocalDateTime salesFrom, LocalDateTime salesTo, String twitterUrl,
+                               String contractAddress, String contractName, LocalDateTime salesFrom, LocalDateTime salesTo, String twitterUrl,
                                String instagramUrl, String webpageUrl, int totalTicketCount, int onSaleTicketCount,
                                LocalDateTime startTime, LocalDateTime endTime, int price, String location, EventSalesOption eventSalesOption) {
         this.id = id;
@@ -47,6 +48,7 @@ public class EventDetailResponse {
         this.artistImage = artistImage;
         this.description = description;
         this.contractAddress = contractAddress;
+        this.openseaUrl = OpenseaCollectionNamingUtil.toOpenseaCollectionUrl(contractName);
         this.salesFrom = DateTimeUtil.toEpochMilliSeconds(salesFrom);
         this.salesTo = DateTimeUtil.toEpochMilliSeconds(salesTo);
         this.twitterUrl = twitterUrl;
@@ -59,9 +61,5 @@ public class EventDetailResponse {
         this.price = price;
         this.location = location;
         this.eventSalesOption = eventSalesOption;
-    }
-
-    public void setOpenseaUrl(String openseaUrl) {
-        this.openseaUrl = openseaUrl;
     }
 }

--- a/src/main/resources/db/migration/V4__add_event_contract_name.sql
+++ b/src/main/resources/db/migration/V4__add_event_contract_name.sql
@@ -1,0 +1,1 @@
+alter table event add column contract_name varchar(255) default "";

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -74,6 +74,7 @@ class EventControllerTest {
         "https://user-images.githubusercontent.com/54073761/179218800-dda72067-3b25-4ca3-b53b-4895c5e49213.jpeg",
         "이씨 콘서트 at Connectable",
         "0x1234abcd",
+        "CONTRACT NAME",
         LocalDateTime.of(2022, 7, 12, 0, 0),
         LocalDateTime.of(2022, 7, 30, 0, 0),
         "https://twitter.com/iamprogrammerio/status/666930927675797504",


### PR DESCRIPTION
## 작업 내용
- Todo로 남겨뒀던, 그 동안은 KAS를 찔러 가져오던 ContractName을 DB에 저장합니다. 
    - 관련 로직에 대해 EventMapper 와 QueryDsl에 약간의 수정이 들어갔습니다. 

- EventMapper에서 TicketToResponse를 변환해줄 때, ownedBy를 무시하여 변환하도록 어노테이션 하나 추가했습니다!
    - 이건 어차피 KAS 갔다와야하는 로직이라 EventMapper 단에서 해결할 수 없는건데, 계속 빌드시 워닝이 나와서 해당 어노테이션 추가했습니다!

## 주의 사항
- Flyway 반영했습니다. Dev 머지되고나서, 직접 쿼리 날려서 Contract name 채워 넣을게요!
- Flyway 잘 되겠지...?

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
