### PR TITLE
feat: 티켓 입장 기능 구현

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/Ticket.java
+++ b/src/main/java/com/backend/connectable/event/domain/Ticket.java
@@ -68,7 +68,7 @@ public class Ticket {
         this.ticketSalesStatus = this.ticketSalesStatus.onSale();
     }
 
-    public void useToEnterEvent() {
+    public void useToEnter() {
         if (this.isUsed) {
             throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.TICKET_ALREADY_USED);
         }

--- a/src/main/java/com/backend/connectable/exception/ErrorType.java
+++ b/src/main/java/com/backend/connectable/exception/ErrorType.java
@@ -42,7 +42,8 @@ public enum ErrorType {
 
     ENTRANCE_ALREADY_DONE("ENTRANCE-001", "입장 처리가 완료된 티켓입니다."),
     ENTRANCE_AUTHORIZATION_NEEDED("ENTRANCE-002", "입장 처리에 대한 권한이 없습니다"),
-    ENTRANCE_QR_EXPIRED("ENTRANCE-003", "만료된 입장 QR 입니다."),
+    ENTRANCE_INFO_NOT_FOUND("ENTRANCE-003", "QR 정보가 만료되었거나 생성되지 않았습니다."),
+    ENTRANCE_INFO_INVALID("ENTRANCE-004", "올바르지 않은 입장 정보입니다."),
 
     ORDER_DETAIL_NOT_EXISTS("ADMIN-001", "존재하지 않는 주문 상세입니다."),
     ADMIN_TOKEN_VERIFY_FAILURE("ADMIN-002", "어드민 토큰이 아닙니다.");

--- a/src/main/java/com/backend/connectable/user/redis/UserTicketEntrance.java
+++ b/src/main/java/com/backend/connectable/user/redis/UserTicketEntrance.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.core.RedisHash;
 
 
 @Getter
-@RedisHash(value = "UserTicketEntrance")
+@RedisHash(value = "UserTicketEntrance", timeToLive = 60)
 public class UserTicketEntrance {
 
     @Id

--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -111,7 +111,7 @@ public class UserService {
         return userTicketService.generateUserTicketEntranceVerification(user, ticketId);
     }
 
-    public UserTicketEntranceResponse verifyTicketEntrance(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
-        return userTicketService.verifyTicketEntrance(ticketId, userTicketEntranceRequest);
+    public UserTicketEntranceResponse useTicketToEnter(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
+        return userTicketService.useTicketToEnter(ticketId, userTicketEntranceRequest);
     }
 }

--- a/src/main/java/com/backend/connectable/user/service/UserTicketService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserTicketService.java
@@ -56,7 +56,7 @@ public class UserTicketService {
         userTicketEntranceRedisRepository.save(userTicketEntrance);
     }
 
-    public UserTicketEntranceResponse verifyTicketEntrance(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
+    public UserTicketEntranceResponse useTicketToEnter(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
         Ticket ticket = eventService.findTicketById(ticketId);
         validateTicketEntrance(ticket, userTicketEntranceRequest);
         ticket.useToEnter();

--- a/src/main/java/com/backend/connectable/user/service/UserTicketService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserTicketService.java
@@ -1,0 +1,85 @@
+package com.backend.connectable.user.service;
+
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.service.EventService;
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
+import com.backend.connectable.global.common.util.RandomStringUtil;
+import com.backend.connectable.security.ConnectableUserDetails;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.redis.UserTicketEntrance;
+import com.backend.connectable.user.redis.UserTicketEntranceRedisRepository;
+import com.backend.connectable.user.ui.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class UserTicketService {
+
+    private final EventService eventService;
+    private final UserTicketEntranceRedisRepository userTicketEntranceRedisRepository;
+
+    @Value("${entrance.device-secret}")
+    private String deviceSecret;
+
+    public UserTicketListResponse getUserTicketsByUserDetails(ConnectableUserDetails userDetails) {
+        String userKlaytnAddress = userDetails.getKlaytnAddress();
+        List<Ticket> tickets = eventService.findTicketByUserAddress(userKlaytnAddress);
+        List<UserTicketResponse> userTicketResponses = UserTicketResponse.toList(tickets);
+        return UserTicketListResponse.of(userTicketResponses);
+    }
+
+    public UserTicketVerificationResponse generateUserTicketEntranceVerification(User user, Long ticketId) {
+        Ticket ticket = eventService.findTicketById(ticketId);
+        if (ticket.isUsed()) {
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ENTRANCE_ALREADY_DONE);
+        }
+
+        String klaytnAddress = user.getKlaytnAddress();
+        String verification = RandomStringUtil.generate();
+        saveUserTicketEntrance(klaytnAddress, ticketId, verification);
+        return UserTicketVerificationResponse.of(klaytnAddress, ticketId, verification);
+    }
+
+    private void saveUserTicketEntrance(String klaytnAddress, Long ticketId, String verification) {
+        UserTicketEntrance userTicketEntrance = UserTicketEntrance.builder()
+            .klaytnAddress(klaytnAddress)
+            .ticketId(ticketId)
+            .verification(verification)
+            .build();
+        userTicketEntranceRedisRepository.save(userTicketEntrance);
+    }
+
+    public UserTicketEntranceResponse verifyTicketEntrance(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
+        Ticket ticket = eventService.findTicketById(ticketId);
+        validateTicketEntrance(ticket, userTicketEntranceRequest);
+        ticket.useToEnter();
+        return UserTicketEntranceResponse.ofSuccess();
+    }
+
+    private void validateTicketEntrance(Ticket ticket, UserTicketEntranceRequest userTicketEntranceRequest) {
+        if (ticket.isUsed()) {
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ENTRANCE_ALREADY_DONE);
+        }
+
+        String deviceSecret = userTicketEntranceRequest.getDeviceSecret();
+        if (!this.deviceSecret.equals(deviceSecret)) {
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ENTRANCE_AUTHORIZATION_NEEDED);
+        }
+
+        String klaytnAddress = userTicketEntranceRequest.getKlaytnAddress();
+        UserTicketEntrance userTicketEntrance = userTicketEntranceRedisRepository.findById(klaytnAddress)
+            .orElseThrow(() -> new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ENTRANCE_INFO_NOT_FOUND));
+
+        if (!Objects.equals(userTicketEntrance.getVerification(), userTicketEntranceRequest.getVerification()) ||
+            !Objects.equals(userTicketEntrance.getTicketId(), ticket.getId())) {
+            throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.ENTRANCE_INFO_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/backend/connectable/user/ui/UserController.java
+++ b/src/main/java/com/backend/connectable/user/ui/UserController.java
@@ -49,6 +49,12 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(userModifyResponse);
     }
 
+    @GetMapping("/validation")
+    public ResponseEntity<UserValidationResponse> validateNickname(@RequestParam String nickname) {
+        UserValidationResponse userValidationResponse = userService.validateNickname(nickname);
+        return ResponseEntity.ok(userValidationResponse);
+    }
+
     @GetMapping("/tickets")
     public ResponseEntity<UserTicketListResponse> getUserTickets(@AuthenticationPrincipal ConnectableUserDetails userDetails) {
         UserTicketListResponse userTicketListResponse = userService.getUserTicketsByUserDetails(userDetails);
@@ -56,15 +62,16 @@ public class UserController {
     }
 
     @GetMapping("/tickets/{ticket-id}/entrance-verification")
-    public ResponseEntity<UserTicketVerificationResponse> getUserTicketEntranceVerification(@AuthenticationPrincipal ConnectableUserDetails userDetails,
-                                                                                            @PathVariable("ticket-id") Long ticketId) {
-        UserTicketVerificationResponse userTicketVerificationResponse = userService.getUserTicketEntranceVerification(userDetails, ticketId);
+    public ResponseEntity<UserTicketVerificationResponse> generateUserTicketEntranceVerification(@AuthenticationPrincipal ConnectableUserDetails userDetails,
+                                                                                                 @PathVariable("ticket-id") Long ticketId) {
+        UserTicketVerificationResponse userTicketVerificationResponse = userService.generateUserTicketEntranceVerification(userDetails, ticketId);
         return ResponseEntity.ok(userTicketVerificationResponse);
     }
 
-    @GetMapping("/validation")
-    public ResponseEntity<UserValidationResponse> validateNickname(@RequestParam String nickname) {
-        UserValidationResponse userValidationResponse = userService.validateNickname(nickname);
-        return ResponseEntity.ok(userValidationResponse);
+    @PostMapping("/tickets/{ticket-id}/enter")
+    public ResponseEntity<UserTicketEntranceResponse> verifyTicketEntrance(@PathVariable("ticket-id") Long ticketId,
+                                                                           @RequestBody UserTicketEntranceRequest userTicketEntranceRequest) {
+        UserTicketEntranceResponse userTicketEntranceResponse = userService.verifyTicketEntrance(ticketId, userTicketEntranceRequest);
+        return ResponseEntity.ok(userTicketEntranceResponse);
     }
 }

--- a/src/main/java/com/backend/connectable/user/ui/UserController.java
+++ b/src/main/java/com/backend/connectable/user/ui/UserController.java
@@ -69,9 +69,9 @@ public class UserController {
     }
 
     @PostMapping("/tickets/{ticket-id}/enter")
-    public ResponseEntity<UserTicketEntranceResponse> verifyTicketEntrance(@PathVariable("ticket-id") Long ticketId,
-                                                                           @RequestBody UserTicketEntranceRequest userTicketEntranceRequest) {
-        UserTicketEntranceResponse userTicketEntranceResponse = userService.verifyTicketEntrance(ticketId, userTicketEntranceRequest);
+    public ResponseEntity<UserTicketEntranceResponse> useTicketToEnter(@PathVariable("ticket-id") Long ticketId,
+                                                                       @RequestBody UserTicketEntranceRequest userTicketEntranceRequest) {
+        UserTicketEntranceResponse userTicketEntranceResponse = userService.useTicketToEnter(ticketId, userTicketEntranceRequest);
         return ResponseEntity.ok(userTicketEntranceResponse);
     }
 }

--- a/src/main/java/com/backend/connectable/user/ui/dto/UserTicketEntranceRequest.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserTicketEntranceRequest.java
@@ -1,0 +1,17 @@
+package com.backend.connectable.user.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTicketEntranceRequest {
+
+    private String klaytnAddress;
+    private String verification;
+    private String deviceSecret;
+}

--- a/src/main/java/com/backend/connectable/user/ui/dto/UserTicketEntranceResponse.java
+++ b/src/main/java/com/backend/connectable/user/ui/dto/UserTicketEntranceResponse.java
@@ -1,0 +1,21 @@
+package com.backend.connectable.user.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTicketEntranceResponse {
+
+    private static final String SUCCESS = "success";
+
+    private String status;
+
+    public static UserTicketEntranceResponse ofSuccess() {
+        return new UserTicketEntranceResponse(SUCCESS);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ sms:
   api-key: NCSDOXRJCN3PNEUL
   api-secret: 6AY7BFTPYTHTYN8QN4E98YSDNPINO9XN
   source-phone-number: 01085161399
+entrance:
+  device-secret: device-secret
 ---
 spring:
   config:
@@ -129,6 +131,8 @@ sms:
   api-key: ${sms.api-key}
   api-secret: ${sms.api-secret}
   source-phone-number: ${sms.source-phone-number}
+entrance:
+  device-secret: ${entrance.device-secret}
 ---
 spring:
   config:
@@ -200,3 +204,5 @@ sms:
   api-key: ${sms.api-key}
   api-secret: ${sms.api-secret}
   source-phone-number: ${sms.source-phone-number}
+entrance:
+  device-secret: ${entrance.device-secret}

--- a/src/test/java/com/backend/connectable/event/domain/TicketTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/TicketTest.java
@@ -34,7 +34,7 @@ class TicketTest {
             .build();
 
         // when & then
-        assertThatCode(ticket::useToEnterEvent).doesNotThrowAnyException();
+        assertThatCode(ticket::useToEnter).doesNotThrowAnyException();
     }
 
     @DisplayName("티켓의 isUsed가 true라면 재입장에 사용할 수 있다.")
@@ -46,10 +46,10 @@ class TicketTest {
             .tokenUri("tokenUri")
             .price(10000)
             .build();
-        ticket.useToEnterEvent();
+        ticket.useToEnter();
 
         // when & then
-        assertThatCode(ticket::useToEnterEvent)
+        assertThatCode(ticket::useToEnter)
             .isInstanceOf(ConnectableException.class);
     }
 }

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -329,7 +329,7 @@ class UserServiceTest {
         given(eventService.findTicketById(ticketId)).willReturn(ticket1);
 
         // when
-        UserTicketVerificationResponse userTicketEntranceVerification = userService.getUserTicketEntranceVerification(connectableUserDetails, ticketId);
+        UserTicketVerificationResponse userTicketEntranceVerification = userService.generateUserTicketEntranceVerification(connectableUserDetails, ticketId);
 
         // then
         assertThat(userTicketEntranceVerification.getKlaytnAddress()).isEqualTo(user1KlaytnAddress);


### PR DESCRIPTION
## 작업 내용
1. **티켓 입장 기능을 구현합니다**
    - API 명세에 따라 티켓 입장 기능을 구현하였습니다
    - redis에서 정보 가져와서 비교하여 구현합니다 
        - 해당 입장 인증 관련 정보를 저장하는 redis는 60초 만료 시간 설정해두었습니다
 
2. **userService에 티켓 관련 정보를 userTicketService로 따로 분류했습니다**
    - 너무 방대해지는 로직을 userTicketService에 따로 관리합니다


## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
