### PR TITLE
fix: 티켓 사용 여부 로직에 Transactional 추가

### DIFF
--- a/src/main/java/com/backend/connectable/user/service/UserService.java
+++ b/src/main/java/com/backend/connectable/user/service/UserService.java
@@ -111,6 +111,7 @@ public class UserService {
         return userTicketService.generateUserTicketEntranceVerification(user, ticketId);
     }
 
+    @Transactional
     public UserTicketEntranceResponse useTicketToEnter(Long ticketId, UserTicketEntranceRequest userTicketEntranceRequest) {
         return userTicketService.useTicketToEnter(ticketId, userTicketEntranceRequest);
     }

--- a/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
+++ b/src/test/java/com/backend/connectable/user/service/UserServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
@@ -349,6 +350,7 @@ class UserServiceTest {
 
     @DisplayName("사전에 생성된 QR 정보를 매칭하여 입장에 사용할 수 있다.")
     @Test
+    @Transactional
     void useTicketToEnter() {
         // given
         given(eventService.findTicketById(ticket1.getId())).willReturn(ticket1);
@@ -364,10 +366,13 @@ class UserServiceTest {
 
         // when
         UserTicketEntranceResponse userTicketEntranceResponse = userService.useTicketToEnter(ticket1.getId(), userTicketEntranceRequest);
+        em.flush();
+        em.clear();
 
         // then
         assertThat(userTicketEntranceResponse.getStatus()).isEqualTo("success");
-        assertThat(ticket1.isUsed()).isTrue();
+        Ticket usedTicket = ticketRepository.findById(ticket1.getId()).get();
+        assertThat(usedTicket.isUsed()).isTrue();
     }
 
     @DisplayName("사전에 생성된 QR 정보에서 device-secret이 다르면 예외가 발생한다.")


### PR DESCRIPTION
## 작업 내용
- Transcational 어노테이션으로 변경감지 지원하도록 합니다!

## 주의 사항
- Transactional(ReadOnly=true)는 변경감지 혜택을 못받는다고 하군요..!
- 엔티티 변경에 있어서는 Transactional 빼놓지 않고 써야겠습니다

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
