### PR TITLE
fix: 유저 토큰 조회시 id와 uri 검증하도록 수정

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepository.java
@@ -15,4 +15,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRep
         "join fetch event.artist as artist " +
         "where ticket.tokenUri in :tokenUris")
     List<Ticket> findAllByTokenUri(@Param("tokenUris") List<String> tokenUris);
+
+    Ticket findByTokenIdAndTokenUri(Integer tokenId, String tokenUri);
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.kas.service.dto.TokenIdentifier;
 
 public interface TicketRepositoryCustom {
 

--- a/src/main/java/com/backend/connectable/kas/service/dto/TokenIdentifier.java
+++ b/src/main/java/com/backend/connectable/kas/service/dto/TokenIdentifier.java
@@ -5,18 +5,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TokenResponse {
-    private String owner;
-    private String previousOwner;
+public class TokenIdentifier {
     private String tokenId;
     private String tokenUri;
-    private String transactionHash;
 
-    public TokenIdentifier generateTokenIdentifier() {
-        return new TokenIdentifier(tokenId, tokenUri);
+    public String getTokenUri() {
+        return tokenUri;
+    }
+
+    public int getTokenId() {
+        return Integer.decode(tokenId);
     }
 }

--- a/src/main/java/com/backend/connectable/kas/service/dto/TokensResponse.java
+++ b/src/main/java/com/backend/connectable/kas/service/dto/TokensResponse.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -19,6 +21,12 @@ public class TokensResponse {
     public List<String> getTokenUris() {
         return items.stream()
             .map(TokenResponse::getTokenUri)
+            .collect(Collectors.toList());
+    }
+
+    public List<TokenIdentifier> getTokenIdentifiers() {
+        return items.stream()
+            .map(TokenResponse::generateTokenIdentifier)
             .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/TicketRepositoryTest.java
@@ -83,18 +83,22 @@ class TicketRepositoryTest {
             .build();
 
     String tokenUri1 = "https://token.uri.1";
+    int tokenId1 = 1;
     Ticket joelTicket1 = Ticket.builder()
-            .event(joelEvent)
-            .tokenUri(tokenUri1)
-            .price(100000)
-            .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-            .ticketMetadata(joelTicket1Metadata)
-            .build();
+        .event(joelEvent)
+        .tokenUri(tokenUri1)
+        .tokenId(tokenId1)
+        .price(100000)
+        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+        .ticketMetadata(joelTicket1Metadata)
+        .build();
 
     String tokenUri2 = "https://token.uri.2";
+    int tokenId2 = 2;
     Ticket joelTicket2 = Ticket.builder()
         .event(joelEvent)
         .tokenUri(tokenUri2)
+        .tokenId(tokenId2)
         .price(100000)
         .ticketSalesStatus(TicketSalesStatus.ON_SALE)
         .ticketMetadata(joelTicket1Metadata)
@@ -145,5 +149,20 @@ class TicketRepositoryTest {
 
         // then
         assertThat(ticket.getTicketSalesStatus()).isEqualTo(TicketSalesStatus.ON_SALE);
+    }
+
+    @DisplayName("토큰 ID와 토큰 URI로 티켓을 찾을 수 있다")
+    @Test
+    void findByTokenIdAndTokenUri() {
+        // given
+        ticketRepository.saveAll(Arrays.asList(joelTicket1, joelTicket2));
+
+        // when
+        Ticket foundTicket1 = ticketRepository.findByTokenIdAndTokenUri(tokenId1, tokenUri1);
+        Ticket foundTicket2 = ticketRepository.findByTokenIdAndTokenUri(tokenId2, tokenUri2);
+
+        // then
+        assertThat(foundTicket1).isEqualTo(joelTicket1);
+        assertThat(foundTicket2).isEqualTo(joelTicket2);
     }
 }

--- a/src/test/java/com/backend/connectable/kas/service/dto/TokenIdentifierTest.java
+++ b/src/test/java/com/backend/connectable/kas/service/dto/TokenIdentifierTest.java
@@ -1,0 +1,18 @@
+package com.backend.connectable.kas.service.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class TokenIdentifierTest {
+
+    @DisplayName("hexadecimal 정보를 integer로 바꿔 가져올 수 있다.")
+    @Test
+    void hexToInt() {
+        TokenIdentifier tokenIdentifier = new TokenIdentifier("0x1a",
+            "https://connectable-events.s3.ap-northeast-2.amazonaws.com/brown-event/json/26.json");
+
+        assertThat(tokenIdentifier.getTokenId()).isEqualTo(26);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 유저 토큰 조회시 id와 uri 검증하도록 수정

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
