### PR TITLE
feat: 이벤트 목록 조회 순서 변경

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -1,8 +1,8 @@
 package com.backend.connectable.event.domain.repository;
 
+import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.dto.EventDetail;
 import com.backend.connectable.event.domain.dto.EventTicket;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +13,6 @@ public interface EventRepositoryCustom {
     List<EventTicket> findAllTickets(Long eventId);
 
     Optional<EventTicket> findTicketByEventIdAndTicketId(Long eventId, Long ticketId);
+
+    List<Event> findAllEvents();
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -14,5 +14,5 @@ public interface EventRepositoryCustom {
 
     Optional<EventTicket> findTicketByEventIdAndTicketId(Long eventId, Long ticketId);
 
-    List<Event> findAllEvents();
+    List<Event> findAllEventWithOrder();
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.backend.connectable.artist.domain.QArtist.artist;
 import static com.backend.connectable.event.domain.QEvent.event;
 import static com.backend.connectable.event.domain.QTicket.ticket;
 
+import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.backend.connectable.event.domain.dto.EventDetail;
 import com.backend.connectable.event.domain.dto.EventTicket;
@@ -16,6 +17,7 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
@@ -137,6 +139,27 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
                         .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<Event> findAllEvents() {
+        List<Event> result =
+                queryFactory
+                        .selectFrom(event)
+                        .orderBy(eventSortSpecifier(), event.salesTo.asc())
+                        .fetch();
+
+        return result;
+    }
+
+    private OrderSpecifier<Integer> eventSortSpecifier() {
+        NumberExpression<Integer> cases =
+                new CaseBuilder()
+                        .when(event.salesTo.after(LocalDateTime.now()))
+                        .then(1)
+                        .otherwise(2);
+
+        return new OrderSpecifier<>(Order.ASC, cases);
     }
 
     private OrderSpecifier<Integer> ticketSortSpecifier() {

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -142,7 +142,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     }
 
     @Override
-    public List<Event> findAllEvents() {
+    public List<Event> findAllEventWithOrder() {
         List<Event> result =
                 queryFactory
                         .selectFrom(event)

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -36,7 +36,7 @@ public class EventService {
     private final TicketRepository ticketRepository;
 
     public List<EventResponse> getList() {
-        List<Event> events = eventRepository.findAllEvents();
+        List<Event> events = eventRepository.findAllEventWithOrder();
         return events.stream()
                 .map(EventMapper.INSTANCE::eventToResponse)
                 .collect(Collectors.toList());

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +36,7 @@ public class EventService {
     private final TicketRepository ticketRepository;
 
     public List<EventResponse> getList() {
-        List<Event> events = eventRepository.findAll(Sort.by(Sort.Direction.ASC, "salesTo"));
+        List<Event> events = eventRepository.findAllEvents();
         return events.stream()
                 .map(EventMapper.INSTANCE::eventToResponse)
                 .collect(Collectors.toList());

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -107,6 +107,24 @@ class EventRepositoryTest {
                 .contains(joelEventContractAddress, ryanEventContractAddress);
     }
 
+    @DisplayName("이벤트 목록을 받아올 수 있다.")
+    @Test
+    void findAllEventWithOrder() {
+        List<Event> events = eventRepository.findAllEventWithOrder();
+        boolean result =
+                List.of(ryanEvent, joelEvent).stream()
+                        .allMatch(
+                                item ->
+                                        events.stream()
+                                                .map(Event::getEventName)
+                                                .filter(
+                                                        eventName ->
+                                                                eventName == item.getEventName())
+                                                .findAny()
+                                                .isPresent());
+        assertThat(result).isTrue();
+    }
+
     @DisplayName("이벤트의 티켓들을 ON_SALE, PENDING, SOLD_OUT, EXPIRED로 가져오며, 이를 id 순으로 정렬하여 가져올 수 있다.")
     @Test
     void findAllTickets() {


### PR DESCRIPTION
## 작업 내용
- 판매중인 이벤트가 상단에 우선 위치
  - 판매중인 이벤트에 대해서는 이벤트 종료일 순서로 오름차순 배치 
 
`
SELECT
    event.*
FROM
    event
ORDER BY
    CASE
        WHEN event.sales_to > NOW() THEN 1
        ELSE 2
    END ASC,
    event.sales_to ASC
`
쿼리 참고 부탁드립니다 :) 🙏 
## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
