### PR TITLE
feat: 티켓 구매시 문자 발송

### DIFF
--- a/src/main/java/com/backend/connectable/admin/service/AdminService.java
+++ b/src/main/java/com/backend/connectable/admin/service/AdminService.java
@@ -13,9 +13,12 @@ import com.backend.connectable.exception.KasException;
 import com.backend.connectable.kas.service.KasService;
 import com.backend.connectable.kas.service.common.dto.TransactionResponse;
 import com.backend.connectable.kas.service.contract.dto.ContractItemResponse;
+import com.backend.connectable.order.domain.Order;
 import com.backend.connectable.order.domain.OrderDetail;
 import com.backend.connectable.order.domain.repository.OrderDetailRepository;
+import com.backend.connectable.order.domain.repository.OrderRepository;
 import com.backend.connectable.s3.service.S3Service;
+import com.backend.connectable.sms.service.SmsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,17 +32,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     private final OrderDetailRepository orderDetailRepository;
+    private final OrderRepository orderRepository;
     private final EventRepository eventRepository;
     private final TicketRepository ticketRepository;
     private final ArtistRepository artistRepository;
     private final KasService kasService;
     private final S3Service s3Service;
+    private final SmsService smsService;
+
+    private static final String paidNotificationMessage = "티켓이 발송완료되었습니다. 마이페이지 > 마이티켓에서 확인부탁드립니다.";
 
     @Transactional
     public void orderDetailToPaid(Long orderDetailId) {
         OrderDetail orderDetail = findOrderDetail(orderDetailId);
+        Order order = findOrderByOrderDetail(orderDetail);
         orderDetail.paid();
         sendTicket(orderDetail);
+        smsService.sendSms(paidNotificationMessage, order.getOrdererPhoneNumber());
     }
 
     private OrderDetail findOrderDetail(Long orderDetailId) {
@@ -49,6 +58,12 @@ public class AdminService {
                         () ->
                                 new ConnectableException(
                                         HttpStatus.BAD_REQUEST, ErrorType.ORDER_DETAIL_NOT_EXISTS));
+    }
+
+    private Order findOrderByOrderDetail(OrderDetail orderDetail) {
+        Long orderId = orderDetail.getOrder().getId();
+        Order order = orderRepository.getReferenceById(orderId);
+        return order;
     }
 
     private void sendTicket(OrderDetail orderDetail) {

--- a/src/main/java/com/backend/connectable/admin/service/AdminService.java
+++ b/src/main/java/com/backend/connectable/admin/service/AdminService.java
@@ -40,15 +40,13 @@ public class AdminService {
     private final S3Service s3Service;
     private final SmsService smsService;
 
-    private static final String paidNotificationMessage = "티켓이 발송완료되었습니다. 마이페이지 > 마이티켓에서 확인부탁드립니다.";
-
     @Transactional
     public void orderDetailToPaid(Long orderDetailId) {
         OrderDetail orderDetail = findOrderDetail(orderDetailId);
         Order order = findOrderByOrderDetail(orderDetail);
         orderDetail.paid();
         sendTicket(orderDetail);
-        smsService.sendSms(paidNotificationMessage, order.getOrdererPhoneNumber());
+        smsService.sendPaidNotification(order.getOrdererPhoneNumber());
     }
 
     private OrderDetail findOrderDetail(Long orderDetailId) {
@@ -62,8 +60,7 @@ public class AdminService {
 
     private Order findOrderByOrderDetail(OrderDetail orderDetail) {
         Long orderId = orderDetail.getOrder().getId();
-        Order order = orderRepository.getReferenceById(orderId);
-        return order;
+        return orderRepository.getReferenceById(orderId);
     }
 
     private void sendTicket(OrderDetail orderDetail) {

--- a/src/main/java/com/backend/connectable/auth/service/AuthService.java
+++ b/src/main/java/com/backend/connectable/auth/service/AuthService.java
@@ -19,8 +19,7 @@ public class AuthService {
 
     public String getAuthKey(String phoneNumber, Long duration) {
         String generatedKey = generateCertificationKey();
-        String message = "Connectable 인증번호는 " + generatedKey + "입니다.";
-        smsService.sendSms(message, phoneNumber);
+        smsService.sendSignUpAuthKey(generatedKey, phoneNumber);
         redisUtil.setDataExpire(phoneNumber, generatedKey, 60 * duration);
         return generatedKey;
     }

--- a/src/main/java/com/backend/connectable/auth/service/AuthService.java
+++ b/src/main/java/com/backend/connectable/auth/service/AuthService.java
@@ -3,41 +3,24 @@ package com.backend.connectable.auth.service;
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.global.common.util.RedisUtil;
+import com.backend.connectable.sms.service.SmsService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import net.nurigo.sdk.NurigoApp;
-import net.nurigo.sdk.message.model.Message;
-import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
-import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AuthService {
 
-    private DefaultMessageService defaultMessageService;
     private final RedisUtil redisUtil;
-
-    @Value("${sms.source-phone-number}")
-    private String sourcePhoneNumber;
-
-    @Value("${sms.api-key}")
-    private String smsApiKey;
-
-    @Value("${sms.api-secret}")
-    private String smsApiSecret;
-
-    private static final String smsApiDomain = "https://api.coolsms.co.kr";
+    private final SmsService smsService;
 
     public String getAuthKey(String phoneNumber, Long duration) {
         String generatedKey = generateCertificationKey();
         String message = "Connectable 인증번호는 " + generatedKey + "입니다.";
-        sendSms(message, phoneNumber);
+        smsService.sendSms(message, phoneNumber);
         redisUtil.setDataExpire(phoneNumber, generatedKey, 60 * duration);
         return generatedKey;
     }
@@ -52,24 +35,6 @@ public class AuthService {
             throw new ConnectableException(HttpStatus.BAD_REQUEST, ErrorType.INVALID_AUTH_KEY);
         }
         return true;
-    }
-
-    private void sendSms(String content, String target) {
-        defaultMessageService =
-                NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
-        Message message = new Message();
-        message.setFrom(sourcePhoneNumber);
-        message.setTo(target.replace("-", ""));
-        message.setText(content);
-        SingleMessageSendingRequest singleMessageSendingRequest =
-                new SingleMessageSendingRequest(message);
-        try {
-            defaultMessageService.sendOne(singleMessageSendingRequest);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            throw new ConnectableException(
-                    HttpStatus.INTERNAL_SERVER_ERROR, ErrorType.NURIGO_EXCEPTION);
-        }
     }
 
     private String generateCertificationKey() {

--- a/src/main/java/com/backend/connectable/sms/config/SmsConfig.java
+++ b/src/main/java/com/backend/connectable/sms/config/SmsConfig.java
@@ -1,0 +1,26 @@
+package com.backend.connectable.sms.config;
+
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SmsConfig {
+
+    private static final String smsApiDomain = "https://api.coolsms.co.kr";
+
+    @Value("${sms.api-key}")
+    private String smsApiKey;
+
+    @Value("${sms.api-secret}")
+    private String smsApiSecret;
+
+    @Bean
+    public DefaultMessageService initMessageService() {
+        return NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
+    }
+}

--- a/src/main/java/com/backend/connectable/sms/service/MessageContent.java
+++ b/src/main/java/com/backend/connectable/sms/service/MessageContent.java
@@ -7,11 +7,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MessageContent {
     SIGNUP_AUTH_REQUEST("Connectable 인증번호는 %s 입니다."),
-    TICKET_ORDER_SUCCREE("티켓이 발송완료되었습니다. 마이페이지 > 마이티켓에서 확인부탁드립니다.");
+    TICKET_ORDER_SUCCESS("티켓이 발송완료되었습니다. 마이페이지 > 마이티켓에서 확인부탁드립니다.");
 
     private final String message;
 
-    public String getAuthSmsMessage(String authKey) {
-        return String.format(message, authKey);
+    public static String getSignUpAuthRequestMessage(String authKey) {
+        return String.format(SIGNUP_AUTH_REQUEST.message, authKey);
+    }
+
+    public static String getTicketOrderSuccess() {
+        return TICKET_ORDER_SUCCESS.message;
     }
 }

--- a/src/main/java/com/backend/connectable/sms/service/MessageContent.java
+++ b/src/main/java/com/backend/connectable/sms/service/MessageContent.java
@@ -1,0 +1,17 @@
+package com.backend.connectable.sms.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageContent {
+    SIGNUP_AUTH_REQUEST("Connectable 인증번호는 %s 입니다."),
+    TICKET_ORDER_SUCCREE("티켓이 발송완료되었습니다. 마이페이지 > 마이티켓에서 확인부탁드립니다.");
+
+    private final String message;
+
+    public String getAuthSmsMessage(String authKey) {
+        return String.format(message, authKey);
+    }
+}

--- a/src/main/java/com/backend/connectable/sms/service/SmsService.java
+++ b/src/main/java/com/backend/connectable/sms/service/SmsService.java
@@ -2,6 +2,7 @@ package com.backend.connectable.sms.service;
 
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
@@ -29,17 +30,21 @@ public class SmsService {
     @Value("${sms.api-secret}")
     private String smsApiSecret;
 
+    @PostConstruct
+    private void initialize() {
+        this.defaultMessageService =
+                NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
+    }
+
     public void sendPaidNotification(String phoneNumber) {
-        sendSms(MessageContent.TICKET_ORDER_SUCCREE.getMessage(), phoneNumber);
+        sendSms(MessageContent.getTicketOrderSuccess(), phoneNumber);
     }
 
     public void sendSignUpAuthKey(String generatedKey, String phoneNumber) {
-        sendSms(MessageContent.SIGNUP_AUTH_REQUEST.getAuthSmsMessage(generatedKey), phoneNumber);
+        sendSms(MessageContent.getSignUpAuthRequestMessage(generatedKey), phoneNumber);
     }
 
     private void sendSms(String content, String target) {
-        defaultMessageService =
-                NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
         Message message = new Message();
         message.setFrom(sourcePhoneNumber);
         message.setTo(target.replace("-", ""));

--- a/src/main/java/com/backend/connectable/sms/service/SmsService.java
+++ b/src/main/java/com/backend/connectable/sms/service/SmsService.java
@@ -1,0 +1,50 @@
+package com.backend.connectable.sms.service;
+
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsService {
+
+    private DefaultMessageService defaultMessageService;
+
+    private static final String smsApiDomain = "https://api.coolsms.co.kr";
+
+    @Value("${sms.source-phone-number}")
+    private String sourcePhoneNumber;
+
+    @Value("${sms.api-key}")
+    private String smsApiKey;
+
+    @Value("${sms.api-secret}")
+    private String smsApiSecret;
+
+    public void sendSms(String content, String target) {
+        defaultMessageService =
+                NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
+        Message message = new Message();
+        message.setFrom(sourcePhoneNumber);
+        message.setTo(target.replace("-", ""));
+        message.setText(content);
+        SingleMessageSendingRequest singleMessageSendingRequest =
+                new SingleMessageSendingRequest(message);
+        try {
+            defaultMessageService.sendOne(singleMessageSendingRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new ConnectableException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ErrorType.NURIGO_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/backend/connectable/sms/service/SmsService.java
+++ b/src/main/java/com/backend/connectable/sms/service/SmsService.java
@@ -2,10 +2,8 @@ package com.backend.connectable.sms.service;
 
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.service.DefaultMessageService;
@@ -18,23 +16,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class SmsService {
 
-    private DefaultMessageService defaultMessageService;
-    private static final String smsApiDomain = "https://api.coolsms.co.kr";
+    private final DefaultMessageService defaultMessageService;
 
     @Value("${sms.source-phone-number}")
     private String sourcePhoneNumber;
-
-    @Value("${sms.api-key}")
-    private String smsApiKey;
-
-    @Value("${sms.api-secret}")
-    private String smsApiSecret;
-
-    @PostConstruct
-    private void initialize() {
-        this.defaultMessageService =
-                NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
-    }
 
     public void sendPaidNotification(String phoneNumber) {
         sendSms(MessageContent.getTicketOrderSuccess(), phoneNumber);

--- a/src/main/java/com/backend/connectable/sms/service/SmsService.java
+++ b/src/main/java/com/backend/connectable/sms/service/SmsService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class SmsService {
 
     private DefaultMessageService defaultMessageService;
-
     private static final String smsApiDomain = "https://api.coolsms.co.kr";
 
     @Value("${sms.source-phone-number}")
@@ -30,7 +29,15 @@ public class SmsService {
     @Value("${sms.api-secret}")
     private String smsApiSecret;
 
-    public void sendSms(String content, String target) {
+    public void sendPaidNotification(String phoneNumber) {
+        sendSms(MessageContent.TICKET_ORDER_SUCCREE.getMessage(), phoneNumber);
+    }
+
+    public void sendSignUpAuthKey(String generatedKey, String phoneNumber) {
+        sendSms(MessageContent.SIGNUP_AUTH_REQUEST.getAuthSmsMessage(generatedKey), phoneNumber);
+    }
+
+    private void sendSms(String content, String target) {
         defaultMessageService =
                 NurigoApp.INSTANCE.initialize(smsApiKey, smsApiSecret, smsApiDomain);
         Message message = new Message();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   config:
     activate:
       on-profile: local
+    import: 'aws-parameterstore:'
   jpa:
     hibernate:
       ddl-auto: create
@@ -28,6 +29,12 @@ spring:
   redis:
     host: 127.0.0.1
     port: 6379
+aws:
+  paramstore:
+    enabled: true
+    prefix: /config
+    profile-separator: _
+    name: connectable
 jwt:
   secret: uacc-to-the-moon
   expire-time: 14400000
@@ -55,9 +62,9 @@ dataloader:
 swagger:
   url: http://localhost:8080
 sms:
-  api-key: NCSDOXRJCN3PNEUL
-  api-secret: 6AY7BFTPYTHTYN8QN4E98YSDNPINO9XN
-  source-phone-number: 01085161399
+  api-key: ${sms.api-key}
+  api-secret: ${sms.api-secret}
+  source-phone-number: ${sms.source-phone-number}
 entrance:
   device-secret: device-secret
 ---

--- a/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/backend/connectable/admin/service/AdminServiceTest.java
@@ -62,7 +62,7 @@ class AdminServiceTest {
             User.builder()
                     .klaytnAddress("0x1234")
                     .nickname("조엘")
-                    .phoneNumber("010-1234-5678")
+                    .phoneNumber("010-8516-1399")
                     .privacyAgreement(true)
                     .isActive(true)
                     .build();
@@ -74,7 +74,7 @@ class AdminServiceTest {
                     .artistName("빅나티")
                     .email("bignaughty@gmail.com")
                     .password("temptemp1234")
-                    .phoneNumber("01012345678")
+                    .phoneNumber("01085161399")
                     .artistImage("ARTIST_IMAGE")
                     .build();
 
@@ -154,7 +154,7 @@ class AdminServiceTest {
             Order.builder()
                     .user(joel)
                     .ordererName("조영상")
-                    .ordererPhoneNumber("010-1234-5678")
+                    .ordererPhoneNumber("010-8516-1399")
                     .build();
 
     OrderDetail orderDetail1;


### PR DESCRIPTION
## 작업 내용
- 티켓 비용 입금 확인 시 문자로 전송

## 주의 사항
- 인증부와 주문쪽에서 모두 SMS 를 사용하여 SMS Service로 뺐습니다.
- 현재 SMS Test 키가 제공되지 않아, 로컬에서 사용하는 키를 분리하여 비활성화/활성화 switch 가능케끔 하였습니다. 
  - CLI를 사용하는 방안등에 대해 고려해보았으나, Production과 유사한 방향으로 가는게 맞다 생각하여 yaml에서 관리되게끔 하였는데, 관련하여 local 환경에서 secret 관리를 하는 best-practice가 있다면 의견 부탁드리겠습니다.
  
<img width="283" alt="image" src="https://user-images.githubusercontent.com/54073761/190180603-a1cc0d86-9b40-4417-83d7-500881683bbd.png">


## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
