### PR TITLE
refactor: 로컬 KAS 파라미터 스토어 도입

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,13 +50,13 @@ logging:
 kas:
   settings:
     enable-global-fee-payer: false
-    account-pool-krn: krn:1001:wallet:664d1c4f-76cc-4664-84cd-f93bd28e3256:account-pool:default
-    account-pool-address: "0xEa06ee0577795e39A0465b46d509168ff6302973"
-    user-fee-payer-krn: krn:1001:wallet:664d1c4f-76cc-4664-84cd-f93bd28e3256:feepayer-pool:default
-    user-fee-payer-address: "0xDFAD470f307CC3C524A96Ea86442F012f1DEF4d6"
-    access-key-id: KASKOOU7SCEQTOSZ2FV0E9UQ
-    secret-access-key: t-gAxJ_10sf7iqvo7qKxRIY6qUsyXMksMS6y0iY7
     chain-id: 1001
+    account-pool-krn: ${kas.account_pool_krn}
+    account-pool-address: ${kas.account_pool_address}
+    user-fee-payer-krn: ${kas.user_fee_payer_krn}
+    user-fee-payer-address: ${kas.user_fee_payer_address}
+    access-key-id: ${kas.access_key_id}
+    secret-access-key: ${kas.secret_access_key}
 dataloader:
   enable: true
 swagger:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,8 @@
     <springProfile name="console-logging">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS}[%-5level] : %msg%n</pattern>
+                <charset>utf8</charset>
+                <Pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%logger{36}] - %m%n</Pattern>
             </encoder>
         </appender>
     </springProfile>

--- a/src/test/java/com/backend/connectable/kas/service/testnet/KasServiceTestWithTestnet.java
+++ b/src/test/java/com/backend/connectable/kas/service/testnet/KasServiceTestWithTestnet.java
@@ -51,7 +51,7 @@ class KasServiceTestWithTestnet {
         System.out.println("MyContract: " + myContractAddresses);
 
         for (String myContractAddress : myContractAddresses) {
-            int randomId = (int) Math.floor(Math.random() * (1000 - 100 + 1) + 100);
+            int randomId = (int) Math.floor(Math.random() * (10000 - 100 + 1) + 100);
             kasService.mintMyToken(
                     myContractAddress,
                     randomId,


### PR DESCRIPTION
## 작업 내용
**1. 로컬 KAS 파라미터 스토어 도입합니다**
    - 로컬 테스트에서 사용할 KAS 정보도 민감정보로 분류하여 파라미터 스토어 도입했습니다
    - 기존에 쓰던 Authentication 정보 삭제하고 새로 발급받아 저장해뒀습니다
    - 알려주신대로 파라미터 스토어 정보 로컬에서 사용하도록 구축했습니다~ 감사합니다

**2. 콘솔 로깅에 쓰레드 정보를 기입합니다**
     - 비동기 처리에 어떤 쓰레드가 사용되는지 쓰레드 정보를 로깅할 필요가 있어보여서 도입합니다. 

**3. KasServiceTestWithTestnet에서 발행하는 tokenId 랜덤값 범위를 늘립니다**
    - 테스트를 많이 돌리다보니, 랜덤으로 생성한 숫자가 이미 있는 숫자라는 응답이 오더군요
    - 테스트 상에서 원래 `000~999` 까지였던 범위를 `0000~9999`로 늘립니다

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
