### PR TITLE
fix: Http Keep-Alive 설정 부여

### DIFF
--- a/src/main/java/com/backend/connectable/kas/config/KasWebClientConfiguration.java
+++ b/src/main/java/com/backend/connectable/kas/config/KasWebClientConfiguration.java
@@ -4,7 +4,9 @@ import okhttp3.Credentials;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class KasWebClientConfiguration {
@@ -23,7 +25,11 @@ public class KasWebClientConfiguration {
 
     @Bean
     public WebClient webClientForKas() {
+        HttpClient httpClient = HttpClient.newConnection().keepAlive(false);
+        ReactorClientHttpConnector httpConnector = new ReactorClientHttpConnector(httpClient);
+
         return WebClient.builder()
+                .clientConnector(httpConnector)
                 .defaultHeaders(
                         headers -> {
                             headers.add("x-chain-id", chainId);


### PR DESCRIPTION
## 작업 내용
1. **계속 발생하는 하나의 에러 메시지**
    - 우리 슬랙에 계속 오는 에러 알람이 하나 있는데요. 아래 에러와 같아요. 
    ```
    19:54:04.891 [ERROR] [reactor-http-epoll-4] [reactor.core.publisher.Operators] - Operator called default onErrorDropped
    reactor.core.Exceptions$ErrorCallbackNotImplemented: org.springframework.web.reactive.function.client.WebClientRequestException: readAddress(..) failed: Connection reset by peer; 
    nested exception is io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
    Caused by: org.springframework.web.reactive.function.client.WebClientRequestException: readAddress(..) failed: Connection reset by peer; 
    nested exception is io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
	    at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.lambda$wrapException$9(ExchangeFunctions.java:141)
	    Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
    Error has been observed at the following site(s):
	    *__checkpoint ⇢ Request to GET https://kip17-api.klaytnapi.com/v2/contract/0xe99540401ef24aba1b7076ea92c94ec38536c6fb/owner/0x3ab31d219d45ce40d6862d68d37de6bb73e21a8d [DefaultWebClient]
    Original Stack Trace:
		    at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.lambda$wrapException$9(ExchangeFunctions.java:141)
		    at reactor.core.publisher.MonoErrorSupplied.subscribe(MonoErrorSupplied.java:55)
		    at reactor.core.publisher.Mono.subscribe(Mono.java:4397)
		    at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:103)
		    at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
		    at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
		    at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
		    at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93)
		    at reactor.core.publisher.MonoFlatMapMany$FlatMapManyMain.onError(MonoFlatMapMany.java:204)
		    at reactor.core.publisher.SerializedSubscriber.onError(SerializedSubscriber.java:124)
		    at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.whenError(FluxRetryWhen.java:225)
		    at reactor.core.publisher.FluxRetryWhen$RetryWhenOtherSubscriber.onError(FluxRetryWhen.java:274)
		    at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.drain(FluxConcatMap.java:415)
		    at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.onNext(FluxConcatMap.java:251)
		    at reactor.core.publisher.EmitterProcessor.drain(EmitterProcessor.java:537)
		    at reactor.core.publisher.EmitterProcessor.tryEmitNext(EmitterProcessor.java:343)
		    at reactor.core.publisher.SinkManySerialized.tryEmitNext(SinkManySerialized.java:100)
		    at reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:27)
		    at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onError(FluxRetryWhen.java:190)
		    at reactor.core.publisher.MonoCreate$DefaultMonoSink.error(MonoCreate.java:201)
		    at reactor.netty.http.client.HttpClientConnect$HttpObserver.onUncaughtException(HttpClientConnect.java:400)
		    at reactor.netty.ReactorNetty$CompositeConnectionObserver.onUncaughtException(ReactorNetty.java:670)
		    at reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire.onUncaughtException(DefaultPooledConnectionProvider.java:205)
		    at reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnection.onUncaughtException(DefaultPooledConnectionProvider.java:454)
		    at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:232)
		    at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:453)
		    at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:488)
		    at reactor.netty.channel.ChannelOperationsHandler.exceptionCaught(ChannelOperationsHandler.java:126)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
		    at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
		    at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireExceptionCaught(CombinedChannelDuplexHandler.java:424)
		    at io.netty.channel.ChannelHandlerAdapter.exceptionCaught(ChannelHandlerAdapter.java:92)
		    at io.netty.channel.CombinedChannelDuplexHandler$1.fireExceptionCaught(CombinedChannelDuplexHandler.java:145)
		    at io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143)
		    at io.netty.channel.CombinedChannelDuplexHandler.exceptionCaught(CombinedChannelDuplexHandler.java:231)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
		    at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
		    at io.netty.handler.ssl.SslHandler.exceptionCaught(SslHandler.java:1105)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
		    at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
		    at io.netty.channel.DefaultChannelPipeline$HeadContext.exceptionCaught(DefaultChannelPipeline.java:1377)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
		    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
		    at io.netty.channel.DefaultChannelPipeline.fireExceptionCaught(DefaultChannelPipeline.java:907)
		    at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.handleReadException(AbstractEpollStreamChannel.java:728)
		    at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:826)
		    at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:487)
		    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:385)
		    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
		    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
		    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		    at java.base/java.lang.Thread.run(Thread.java:829)
    Caused by: io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer```
    ```
    - 해당 에러는 Kas 모듈에서 발생하는데요
    - WebClient를 통해 Http 호출을 할 때, **Connection Reset By Peer** 라는 에러가 뜨는것을 확인할 수 있어요
    - 우선 해당 에러는 반대 서버측에서 커넥션을 끊어버렸다~ 라는 뜻인데요. 
    - 사실 이걸 어떻게 고쳐야할지, 어떤게 문제일지 좀 찾기가 어려웠어요. WebClient 사용할때 많이들 마주하는 에러 같긴 하더군요
        - *참고: https://github.com/reactor/reactor-netty/issues/388*
    - 우선 제가 생각해본 문제점과 해결책은 다음과 같습니다. 


2. **Http Keep-Alive**
    - 해당 에러는 클라이언트가 커넥션을 만들어둔거에서 그 다음 리퀘스트가 fail 한 경우에 발생한다고 해요. 
    - 커넥션이라고 하면 Http의 Keep-Alive를 생각해볼 수 있을 것 같아요. 
      - Keep-Alive는 TIL에 기록해뒀으니 참고하셔도 좋을 듯 합니다. (https://github.com/joelonsw/TIL/blob/master/2022-09/2022-09-27.md#keep-alive)
    - 간략히는 매번 HTTP 통신 할 때 마다 TCP-3-way-handshake를 방지하려고 클라이언트/서버가 일정 시간만큼 커넥션을 유지시키자는 http 프로토콜 상의 약속정도라고 보시면 될 것 같아요. 
    - HTTP/1.1의 경우 keep-alive 속성이 디폴트라는데, KAS에서 지원을 안 하는 건가 싶습니다. 
       - 우선 KAS에 요청을 보냈을 때, Keep-Alive 속성이 응답으로 오진 않더라고요...
       - ![스크린샷 2022-09-27 오후 11 32 29](https://user-images.githubusercontent.com/61370901/192555373-ea8072a7-c3cb-4cbf-a9eb-71a393d4692d.png)
    - 제 가설은 우리 서버에서는 HTTP 요청에 사용한 소켓을 가지고 있다가 3-way-handshake 없이 나중에 또 쓸라고 했는데, KAS에서는 한번 응답해버린 커넥션을 서버에서 종료해버려서 이런 에러가 뜨는게 아닌가 싶습니다. 

3. **따라서 KasWebClient에 Keep-Alive false를 해버립니다**
    - 이러면 모든 HTTP 요청에 대해 TCP 3-way-handshake를 해야할 것이에요. 
    - 당연히 Keep-Alive를 통해 소켓 통신의 수명을 늘려 HTTP 프로토콜만 왔다갔다 하는것보단 더 오래걸리겠죠. 
    - 하지만 뭐 KAS에서 Keep-Alive를 지원을 안하면 어쩔수가 없는 것 같습니다. (내 추측)
    - 옛날에 쓰던 커넥션 또 써서 응답 실패해서 다시 TCP 3-way-handshake 하는것 보다야 매번 TCP-3-way-handshake를 하는편이 더 낫죠. 
    - 읽어보시고 다양한 의견 주세요! 

## 주의 사항
- 로컬에서 테스트하는건 조금 한계가 있어보여서, 우선 데브에 올리고 경과를 한번 지켜봐 봅시다!
- 하루종일 WebClient 공부했는데 재미있더군요... node.js, nginx 처럼 이벤트 기반 처리 서버 기술이 왜 유의미한지 조금 느낀것같습니다. 서버의 리소스를 가장 바쁘게 활용할 수 있는 방법인 것 같더군요. 
- 물론 전 여전히 Spring MVC를 좋아합니다. 동기적으로 동작해야 뭐가 잘못됐는지 알아서 뚝딱 고쳐서 생산성이 더 좋아지는 것 같거든요. 
- 공부하면서 가장 재밌게 읽은 글 공유드립니다 : https://alwayspr.tistory.com/44
- 그리고 CS 기초의 중요함을 좀 느꼈습니다. 
  - 공부하다보면 네트워크 지식이 여기저기 나오더군요. TCP/HTTP 프로토콜을 잘 이해해야겠습니다.
  - 특히 RestTemplate (Sync/Blocking) vs WebClient(Async/Non-Blocking) 을 비교하는 파트에서는 순식간에 운영체제 개념을 왔다갔다 하더라고요. 
      - 어플리케이션 쓰레드가 작업 중에 외부 네트워크나 DB를 호출하면 I/O가 발생한다고 하잖습니까? (인터럽트라고 했던거 같기도 하고요) 
      - 해당 작업을 처리하기 위해 커널 쓰레드에게 제어권을 넘겨 외부 네트워크/DB에 필요한 처리를 진행하고요. 
      - 이렇게 되면 어플리케이션 쓰레드가 I/O에 대한 응답을 받을 때 까지 idle 상태, 운영체제에서 배운 용어로는 어플리케이션 쓰레드가 wait 상태로 변경되고요. 해당 어플리케이션 쓰레드가 wait 상태로 변경되면 CPU는 Context-Switching을 통해 다른 어플리케이션 쓰레드의 일처리를 도와주겠죠? 
      - 커널 쓰레드가 외부 I/O 작업을 끝마치면 어플리케이션 쓰레드를 wait 상태에서 ready 상태로 변경 시켜줘서 CPU가 다시 어플리케이션 쓰레드의 작업들을 수행할 수 있게 해주겠죠...  
      - 요렇게 돌아가는데 동기/블럭킹의 구조 인 것 같다는 생각이 들더랍니다. 
          - ![image](https://user-images.githubusercontent.com/61370901/192560119-501b93dc-b2ba-4211-b8be-7a04e2c8a41e.png)
      - 제가 느낀 비동기/논블로킹은 애초에 어플리케이션 쓰레드를 idle 상태에 빠지게 안하려고 노력하는 느낌입니다. 
      - 어플리케이션 쓰레드가 작업중에 외부 네트워크나 DB I/O가 필요하다면, 어플리케이션 쓰레드가 가진 작업의 제어권을 커널 쓰레드로 넘겨주는게 아니라, 
      - 커널 쓰레드는 별도로 I/O 작업을 하고 어플리케이션 쓰레드는 그 다음 일처리를 진행합니다. (이러면 wait 상태로 쓰레드가 넘어가지 않겠죠. Context-Switching이 필요없는것도 좋고요)
      - 커널 쓰레드가 별도의 I/O 작업을 끝내면 어플리케이션의 EventListener 한테 해당 작업 끝났어~ 라고 알려주고, 
      - EventListener 측에서 특정 이벤트 발행 시 실행시켜야 할 어플리케이션 쓰레드의 코드들을 쓱 실행시키는 것 같습니다. 
      - 당연히 더 빠르겠다는 생각이 들더라고요. 컨텍스트 스위칭 비용도 최대한 적게 들고요. 
      - 얼마전에 테코톡 nginx vs apache 를 살짝 봤는데 (https://www.youtube.com/watch?v=6FAwAXXj5N0&t=11s) 요게 그소리겠거니 이해되더랍니다. 
      
- 물론 얄팍한 지식이라 피드백 주시면 같이 얘기해봅시다! 파이썬 진영은 어떻게 동기/비동기를 사용하는지, 어떤게 왜 빨랐던 건지 인사이트가 있으셨다면 공유해주셔도 좋을 것 같습니다~

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
