### PR TITLE
test: Klaytn 관련 테스트 작성

### DIFF
--- a/src/main/java/com/backend/connectable/klip/config/KlipRestTemplate.java
+++ b/src/main/java/com/backend/connectable/klip/config/KlipRestTemplate.java
@@ -1,0 +1,14 @@
+package com.backend.connectable.klip.config;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KlipRestTemplate {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public <T> T getForEntity(String url, Class<T> responseType) {
+        return restTemplate.getForEntity(url, responseType).getBody();
+    }
+}

--- a/src/main/java/com/backend/connectable/klip/service/KlipService.java
+++ b/src/main/java/com/backend/connectable/klip/service/KlipService.java
@@ -1,29 +1,31 @@
 package com.backend.connectable.klip.service;
 
+import com.backend.connectable.klip.config.KlipRestTemplate;
 import com.backend.connectable.klip.service.dto.KlipAuthHandleResponse;
 import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 @Service
+@RequiredArgsConstructor
 public class KlipService {
 
-    private static final String KLIP_AUTH_LOGIN_URL = "https://a2a-api.klipwallet.com/v2/a2a/result?request_key=";
+    private static final String KLIP_AUTH_LOGIN_URL =
+            "https://a2a-api.klipwallet.com/v2/a2a/result?request_key=";
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final KlipRestTemplate klipRestTemplate;
 
     public KlipAuthLoginResponse authLogin(String requestKey) {
         String requestUrl = KLIP_AUTH_LOGIN_URL + requestKey;
         try {
             KlipAuthHandleResponse klipAuthHandleResponse =
-                    restTemplate.getForEntity(requestUrl, KlipAuthHandleResponse.class).getBody();
+                    klipRestTemplate.getForEntity(requestUrl, KlipAuthHandleResponse.class);
             if (klipAuthHandleResponse.isPrepared()) {
                 return KlipAuthLoginResponse.ofPrepared();
             }
-            String klaytnAddress = klipAuthHandleResponse.getResult()
-                    .getKlaytn_address()
-                    .toLowerCase();
+            String klaytnAddress =
+                    klipAuthHandleResponse.getResult().getKlaytn_address().toLowerCase();
             return KlipAuthLoginResponse.ofCompleted(klaytnAddress);
         } catch (RestClientException | NullPointerException e) {
             return KlipAuthLoginResponse.ofFailed();

--- a/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
+++ b/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
@@ -120,14 +120,34 @@ public class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String tokenId = "0x1";
+        int tokenIdByInt = 1;
         String tokenUri = "https://token.uri";
 
         // when
-        TransactionResponse response = kasService.mintMyToken(contractAddress, tokenId, tokenUri);
+        TransactionResponse response1 = kasService.mintMyToken(contractAddress, tokenId, tokenUri);
+        TransactionResponse response2 =
+                kasService.mintMyToken(contractAddress, tokenIdByInt, tokenUri);
 
         // then
-        assertThat(response.getStatus()).isNotEmpty();
-        assertThat(response.getTransactionHash()).isNotEmpty();
+        assertThat(response1.getStatus()).isNotEmpty();
+        assertThat(response1.getTransactionHash()).isNotEmpty();
+
+        assertThat(response2.getStatus()).isNotEmpty();
+        assertThat(response2.getTransactionHash()).isNotEmpty();
+    }
+
+    @DisplayName("KAS를 통해 해당 컨트랙트에 민팅된 토큰을 전체 조회할 수 있다.")
+    @Test
+    void getTokens() {
+        // given
+        String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
+
+        // when
+        TokensResponse response = kasService.getTokens(contractAddress);
+
+        // then
+        assertThat(response.getItems()).isNotNull();
+        assertThat(response.getTokenUris()).isNotNull();
     }
 
     @DisplayName("KAS를 통해 민팅된 토큰을 조회할 수 있다.")
@@ -136,14 +156,20 @@ public class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String tokenId = KasMockRequest.VALID_TOKEN_ID;
+        int tokenIdByInt = KasMockRequest.VALID_TOKEN_ID_BY_INT;
 
         // when
-        TokenResponse response = kasService.getToken(contractAddress, tokenId);
+        TokenResponse response1 = kasService.getToken(contractAddress, tokenId);
+        TokenResponse response2 = kasService.getToken(contractAddress, tokenIdByInt);
 
         // then
-        assertThat(response.getOwner()).isNotEmpty();
-        assertThat(response.getTokenId()).isNotEmpty();
-        assertThat(response.getTransactionHash()).isNotEmpty();
+        assertThat(response1.getOwner()).isNotEmpty();
+        assertThat(response1.getTokenId()).isNotEmpty();
+        assertThat(response1.getTransactionHash()).isNotEmpty();
+
+        assertThat(response2.getOwner()).isNotEmpty();
+        assertThat(response2.getTokenId()).isNotEmpty();
+        assertThat(response2.getTransactionHash()).isNotEmpty();
     }
 
     @DisplayName("KAS를 통해 민팅되지 않은 토큰은 조회시 KasException이 발생한다.")
@@ -164,14 +190,20 @@ public class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String tokenId = KasMockRequest.VALID_TOKEN_ID;
+        int tokenIdByInt = KasMockRequest.VALID_TOKEN_ID_BY_INT;
         String owner = KasMockRequest.VALID_OWNER_ADDRESS;
 
         // when
-        TransactionResponse response = kasService.sendMyToken(contractAddress, tokenId, owner);
+        TransactionResponse response1 = kasService.sendMyToken(contractAddress, tokenId, owner);
+        TransactionResponse response2 =
+                kasService.sendMyToken(contractAddress, tokenIdByInt, owner);
 
         // then
-        assertThat(response.getTransactionHash()).isNotEmpty();
-        assertThat(response.getStatus()).isNotEmpty();
+        assertThat(response1.getTransactionHash()).isNotEmpty();
+        assertThat(response1.getStatus()).isNotEmpty();
+
+        assertThat(response2.getTransactionHash()).isNotEmpty();
+        assertThat(response2.getStatus()).isNotEmpty();
     }
 
     @DisplayName("민팅되지 않은 토큰을 전송시, KasException이 발생한다.")
@@ -193,13 +225,18 @@ public class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String tokenId = KasMockRequest.VALID_TOKEN_ID;
+        int tokenIdByInt = KasMockRequest.VALID_TOKEN_ID_BY_INT;
 
         // when
-        TransactionResponse response = kasService.burnMyToken(contractAddress, tokenId);
+        TransactionResponse response1 = kasService.burnMyToken(contractAddress, tokenId);
+        TransactionResponse response2 = kasService.burnMyToken(contractAddress, tokenIdByInt);
 
         // then
-        assertThat(response.getStatus()).isNotEmpty();
-        assertThat(response.getTransactionHash()).isNotEmpty();
+        assertThat(response1.getStatus()).isNotEmpty();
+        assertThat(response1.getTransactionHash()).isNotEmpty();
+
+        assertThat(response2.getStatus()).isNotEmpty();
+        assertThat(response2.getTransactionHash()).isNotEmpty();
     }
 
     @DisplayName("토큰의 소유자 변경 이력을 조회할 수 있다.")
@@ -208,13 +245,19 @@ public class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String tokenId = KasMockRequest.VALID_TOKEN_ID;
+        int tokenIdByInt = KasMockRequest.VALID_TOKEN_ID_BY_INT;
 
         // when
-        TokenHistoriesResponse response = kasService.getTokenHistory(contractAddress, tokenId);
+        TokenHistoriesResponse response1 = kasService.getTokenHistory(contractAddress, tokenId);
+        TokenHistoriesResponse response2 =
+                kasService.getTokenHistory(contractAddress, tokenIdByInt);
 
         // then
-        assertThat(response.getCursor()).isNotEmpty();
-        assertThat(response.getItems()).isNotNull();
+        assertThat(response1.getCursor()).isNotEmpty();
+        assertThat(response1.getItems()).isNotNull();
+
+        assertThat(response2.getCursor()).isNotEmpty();
+        assertThat(response2.getItems()).isNotNull();
     }
 
     @DisplayName("사용자가 소유한 모든 토큰을 조회할 수 있다.")

--- a/src/test/java/com/backend/connectable/kas/service/mockserver/KasMockRequest.java
+++ b/src/test/java/com/backend/connectable/kas/service/mockserver/KasMockRequest.java
@@ -16,6 +16,7 @@ public class KasMockRequest {
     public static String INVALID_CONTRACT_ADDRESS = "0x5678";
 
     public static String VALID_TOKEN_ID = "0x1";
+    public static int VALID_TOKEN_ID_BY_INT = 1;
 
     public static String INVALID_TOKEN_ID = "1";
 

--- a/src/test/java/com/backend/connectable/klip/service/KlipServiceTest.java
+++ b/src/test/java/com/backend/connectable/klip/service/KlipServiceTest.java
@@ -1,0 +1,87 @@
+package com.backend.connectable.klip.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.backend.connectable.klip.config.KlipRestTemplate;
+import com.backend.connectable.klip.service.dto.KlipAuthHandleKlaytnAddressResponse;
+import com.backend.connectable.klip.service.dto.KlipAuthHandleResponse;
+import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.client.RestClientException;
+
+@SpringBootTest
+class KlipServiceTest {
+
+    private static final String klaytnAddress = "0x1234";
+
+    private static final KlipAuthHandleResponse preparedAuthHandleResponse =
+            new KlipAuthHandleResponse(
+                    "cb4cb3a6-1695-437f-98ef-66aadc9ab46c", "prepared", "1664330074", null);
+
+    private static final KlipAuthHandleResponse completedAuthHandleResponse =
+            new KlipAuthHandleResponse(
+                    "9d3fa8c4-740d-4617-99fe-f7f54a4d1b91",
+                    "completed",
+                    "1664330178",
+                    new KlipAuthHandleKlaytnAddressResponse(klaytnAddress));
+
+    private static final KlipAuthHandleResponse failedAuthHandleResponse =
+            new KlipAuthHandleResponse(
+                    "a39s9csb-1695-097f-98ef-129jxh66aadc", "failed", "1664330074", null);
+
+    @Autowired KlipService klipService;
+
+    @MockBean KlipRestTemplate klipRestTemplate;
+
+    @DisplayName("해당 requestKey를 통해 요청시 준비중이라면, status Prepared를 응답한다.")
+    @Test
+    void authLoginPrepared() {
+        // given
+        given(klipRestTemplate.getForEntity(any(), eq(KlipAuthHandleResponse.class)))
+                .willReturn(preparedAuthHandleResponse);
+
+        // when
+        KlipAuthLoginResponse klipAuthLoginResponse = klipService.authLogin("prepared");
+
+        // then
+        assertThat(klipAuthLoginResponse.getKlaytnAddress()).isEmpty();
+        assertThat(klipAuthLoginResponse.getStatus()).isEqualTo("prepared");
+    }
+
+    @DisplayName("해당 requestKey를 통해 요청 시 완료되었다면, status Completed를 응답한다.")
+    @Test
+    void authLoginCompleted() {
+        // given
+        given(klipRestTemplate.getForEntity(any(), eq(KlipAuthHandleResponse.class)))
+                .willReturn(completedAuthHandleResponse);
+
+        // when
+        KlipAuthLoginResponse klipAuthLoginResponse = klipService.authLogin("completed");
+
+        // then
+        assertThat(klipAuthLoginResponse.getKlaytnAddress()).isEqualTo(klaytnAddress);
+        assertThat(klipAuthLoginResponse.getStatus()).isEqualTo("completed");
+    }
+
+    @DisplayName("해당 requestKey를 통해 요청 시 실패하였다면, status Failed를 응답한다.")
+    @Test
+    void authLoginFailed() {
+        // given
+        given(klipRestTemplate.getForEntity(any(), eq(KlipAuthHandleResponse.class)))
+                .willThrow(new RestClientException("failed!"));
+
+        // when
+        KlipAuthLoginResponse klipAuthLoginResponse = klipService.authLogin("failed");
+
+        // then
+        assertThat(klipAuthLoginResponse.getKlaytnAddress()).isEmpty();
+        assertThat(klipAuthLoginResponse.getStatus()).isEqualTo("failed");
+    }
+}


### PR DESCRIPTION
## 작업 내용
1. **외부 모듈을 활용하는 Klip/Kas 에 대한 테스트를 작성합니다**
    - 우선 우리 백엔드 측에서 엔드포인트를 열어주고 사용하는 모듈이 아니라, 그냥 http 통신을 통해 외부와 통신하는 모듈이라서 서비스 테스트만 진행했습니다. 
    - Klip의 경우 RestTemplate을 mocking 하기 위해 따로 RestTemplate은 config 패키지로 뺐습니다. 
    - 라인 커버리지는 아래와 같습니다. 
    <img width="656" alt="스크린샷 2022-09-28 오전 11 33 12" src="https://user-images.githubusercontent.com/61370901/192675023-6d7faabc-22bc-4645-9082-a6ce4a41e38d.png">


## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
