### PR TITLE
test: 가입시 인증 로직 테스트 코드 작성

### DIFF
--- a/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,73 @@
+package com.backend.connectable.acceptance;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("local")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AuthAcceptanceTest {
+
+    private static final String 인증_요청_핸드폰_번호1 = "010-1234-1234";
+    private static final Long 인증_요청_유효_기간 = 1L;
+
+    @LocalServerPort public int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("요청하여 응답받은 인증키를 이용하여 인증시 성공한다")
+    @Test
+    void successCertification() {
+        // given & when
+        String 응답받은_인증키 = 인증키를_요청한다();
+        Boolean 요청_성공_여부 = 인증키를_검증한다(응답받은_인증키);
+
+        // then
+        assertThat(요청_성공_여부).isTrue();
+    }
+
+    private static String 인증키를_요청한다() {
+        return RestAssured.given()
+                .log()
+                .all()
+                .contentType("text/plain")
+                .param("phoneNumber", 인증_요청_핸드폰_번호1)
+                .param("duration", 인증_요청_유효_기간)
+                .when()
+                .get("/auth/sms/key")
+                .then()
+                .log()
+                .all()
+                .extract()
+                .body()
+                .asString();
+    }
+
+    private static Boolean 인증키를_검증한다(String 인증키) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .contentType("text/plain")
+                .param("phoneNumber", 인증_요청_핸드폰_번호1)
+                .param("authKey", 인증키)
+                .when()
+                .get("/auth/sms/certification")
+                .then()
+                .log()
+                .all()
+                .extract()
+                .response()
+                .as(Boolean.class);
+    }
+}

--- a/src/test/java/com/backend/connectable/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/backend/connectable/auth/service/AuthServiceTest.java
@@ -1,3 +1,63 @@
 package com.backend.connectable.auth.service;
 
-class AuthServiceTest {}
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.backend.connectable.exception.ConnectableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired private AuthService authService;
+
+    private final String phoneNumber = "010-2222-3333";
+    private final Long duration = 1L;
+
+    @DisplayName("인증키 획득 요청시 문자열 형태의 인증키를 반환받는다.")
+    @Test
+    void getAuthKey() {
+        // given & when
+        String authKey = authService.getAuthKey(phoneNumber, duration);
+
+        // then
+        assertThat(authKey).isNotBlank();
+    }
+
+    @DisplayName("발급받은 인증키로 인증 시 검증에 성공한다.")
+    @Test
+    void certifyKey() {
+        // give & when
+        String generatedKey = authService.getAuthKey(phoneNumber, duration);
+        Boolean isCertified = authService.certifyKey(phoneNumber, generatedKey);
+
+        // then
+        assertThat(isCertified).isTrue();
+    }
+
+    @DisplayName("서로 다른 요청에 의해 발급된 인증키는 같지 않아야 한다.")
+    @Test
+    void getAuthKeyDifference() {
+        // given & when
+        String generatedKey1 = authService.getAuthKey(phoneNumber, duration);
+        String generatedKey2 = authService.getAuthKey(phoneNumber, duration);
+
+        // then
+        assertThat(generatedKey1).isNotEqualTo(generatedKey2);
+    }
+
+    @DisplayName("인증에 실패시 false값을 예외처리에 의해 ConnectableException을 발생시킨다.")
+    @Test
+    void validateAuthKeyFail() {
+        // given & when
+        String generatedKey = authService.getAuthKey(phoneNumber, duration);
+        String authKey = "a1b2c3";
+
+        // then
+        assertThatThrownBy(() -> authService.certifyKey(generatedKey, authKey))
+                .isInstanceOf(ConnectableException.class);
+    }
+}

--- a/src/test/java/com/backend/connectable/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/backend/connectable/auth/ui/AuthControllerTest.java
@@ -1,0 +1,77 @@
+package com.backend.connectable.auth.ui;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.backend.connectable.auth.service.AuthService;
+import com.backend.connectable.security.JwtAuthenticationFilter;
+import com.backend.connectable.security.SecurityConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = {
+            @ComponentScan.Filter(
+                    type = FilterType.ASSIGNABLE_TYPE,
+                    classes = {SecurityConfiguration.class, JwtAuthenticationFilter.class})
+        })
+@MockBean(JpaMetamodelMappingContext.class)
+class AuthControllerTest {
+
+    private static final String PHONE_NUMBER = "010-2222-3333";
+    private static final Long DURATION = 1L;
+    private static final String AUTH_KEY = "123123";
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private AuthService authService;
+
+    @DisplayName("비회원으로 인증키 요청시 문자열의 인증키를 받는데 성공한다.")
+    @WithMockUser
+    @Test
+    void getAuthKeySuccess() throws Exception {
+        // given & when
+        given(authService.getAuthKey(PHONE_NUMBER, DURATION)).willReturn(AUTH_KEY);
+
+        mockMvc.perform(
+                        get(
+                                        "/auth/sms/key?phoneNumber={phone-number}&duration={duration}",
+                                        PHONE_NUMBER,
+                                        DURATION)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(AUTH_KEY))
+                .andDo(print());
+    }
+
+    @DisplayName("비회원으로 인증키 검증 성공시 boolean=true를 반환받는다.")
+    @WithMockUser
+    @Test
+    void certifyAuthKeySuccess() throws Exception {
+        // given & when
+        boolean isCertified = true;
+        given(authService.certifyKey(PHONE_NUMBER, AUTH_KEY)).willReturn(isCertified);
+
+        // then
+        mockMvc.perform(
+                        get(
+                                        "/auth/sms/certification?phoneNumber={phone-number}&authKey={authKey}",
+                                        PHONE_NUMBER,
+                                        AUTH_KEY)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 문자 인증을 받는 부분의 인증 기능 테스트 작성 추가하였습니다.
  - 인증키를 받고, 해당 키로 인증 성공하는 것까지의 시나리오만을 인수테스트 진행하였습니다.
  - 단위 테스트 > 통합 테스트 > 인수 테스트 순으로 테스트 개수를 가지도록 하였습니다. 
    - [마틴 파울러의 피라미드](https://martinfowler.com/articles/practical-test-pyramid.html) 를 따랐는데요, 인수테스트나 통합테스트가 무거워질수록 빌드타임에 영향을 끼칠듯 하여 서비스 레이어 테스트를 풍부하게 가는 기조로 작성했습니다.  
 ### AS-IS
<img width="599" alt="스크린샷 2022-09-29 오전 12 33 47" src="https://user-images.githubusercontent.com/54073761/192822274-dbbaf59f-7fd0-4fb8-abaa-99d2ed96a4ec.png">

 ### TO-BE
<img width="602" alt="스크린샷 2022-09-29 오전 12 33 33" src="https://user-images.githubusercontent.com/54073761/192822375-604efe0d-33f9-483c-b318-b46e728a53c6.png">

## 주의 사항
1. private 메소드를 테스트 하는 것에 대한 고민
private method를 테스트 하는 것을 고민해보았습니다.
```
@DisplayName("인증키 생성시마다 랜덤한 문자열이 생성된다.")
@Test
void generateCertificationKey()
        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {

    // given & when
    Method method = AuthService.class.getDeclaredMethod("generateCertificationKey");
    method.setAccessible(true);

    String actual1 = (String) method.invoke(authService);
    String actual2 = (String) method.invoke(authService);

    // then
    assertThat(actual1).isNotEqualTo(actual2);
}
```

private 메소드를 사용하는 public 메소드에서 충분한 검증이 이뤄져야 한다는 생각으로 귀결되어 private method 테스트는 진행하지 않았는데요, public이 아닌 메소드들의 테스트에 대해 어떤식으로 테스트를 할지 의견 부탁드리겠습니다 :) 

2. 라인 커버리지 100%?
[토스의 테스트 커버리지 영상](https://www.youtube.com/watch?v=jdlBu2vFv58)을 보면, 100% 로 커버리지 목표를 잡은 이유가 상당히 reasonable해보입니다. 
다만, 라인 커버리지에서 벗어나 엣지 케이스를 어떤식으로 정립하고 테스트 코드를 작성할 것인가에 대해서는 아직 고민이 많습니다.. 이 부분도 정책으로 세울 수 있다면 같이 이야기해보아도 좋을 것 같아요 :) ( 아직도 테스트 코드 작성에 어려움이 많네요.. ㅎㅎ )

3. 인증부랑 결합이 되어있는 SMS 테스트 고민
이번에 인증쪽을 테스트 하면서 SMS도 Event(Pub-Sub) 구조로 결합도를 떨어뜨리면서 같이 테스트를 진행하려 하였습니다.
-> [이슈](https://github.com/Team-UACC/connectable-backend/issues/136)
Auth 도메인이랑 Order 도메인에 SMS가 결합되어있는데, Topic별로 관리하는 것에 어려움이 있어 삽질을 좀 깊게 하고 있습니다.
도메인 별로 Pub-Sub Topic을 관리하는 방법에 대한 고민이 필요하여, 후순위로 미뤄두겠습니다. ( 좋은 의견이 있다면 부탁드립니다 🙏 )

4. 테스트 공통 부분
ControllerTest나 AcceptanceTest 작성시 공통으로 사용되는 부분이 많아보여요 !
추상 클래스로 빼는 등의 리팩토링을 추후 같이해보면 어떨까요 ! ;)

**Reference**
- https://stackoverflow.com/questions/105007/should-i-test-private-methods-or-only-public-ones#105021
- https://fishbowl.pastiche.org/2003/03/28/testing_private_methods_dont_do_it
## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
