### PR TITLE
test: OrderControllerTest 추가

### DIFF
--- a/src/main/java/com/backend/connectable/kas/service/contract/KasContractService.java
+++ b/src/main/java/com/backend/connectable/kas/service/contract/KasContractService.java
@@ -2,7 +2,10 @@ package com.backend.connectable.kas.service.contract;
 
 import com.backend.connectable.kas.config.KasWebClient;
 import com.backend.connectable.kas.service.common.endpoint.EndPointGenerator;
-import com.backend.connectable.kas.service.contract.dto.*;
+import com.backend.connectable.kas.service.contract.dto.ContractDeployRequest;
+import com.backend.connectable.kas.service.contract.dto.ContractDeployResponse;
+import com.backend.connectable.kas.service.contract.dto.ContractItemResponse;
+import com.backend.connectable.kas.service.contract.dto.ContractItemsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
@@ -1,6 +1,6 @@
 package com.backend.connectable.acceptance;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/backend/connectable/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/backend/connectable/auth/service/AuthServiceTest.java
@@ -1,6 +1,6 @@
 package com.backend.connectable.auth.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.backend.connectable.exception.ConnectableException;

--- a/src/test/java/com/backend/connectable/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/backend/connectable/auth/ui/AuthControllerTest.java
@@ -1,10 +1,11 @@
 package com.backend.connectable.auth.ui;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.backend.connectable.auth.service.AuthService;
 import com.backend.connectable.security.config.SecurityConfiguration;

--- a/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
+++ b/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.kas.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.backend.connectable.exception.KasException;
 import com.backend.connectable.kas.service.common.dto.TransactionResponse;

--- a/src/test/java/com/backend/connectable/order/ui/OrderControllerTest.java
+++ b/src/test/java/com/backend/connectable/order/ui/OrderControllerTest.java
@@ -1,0 +1,161 @@
+package com.backend.connectable.order.ui;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.backend.connectable.event.domain.TicketSalesStatus;
+import com.backend.connectable.order.domain.OrderStatus;
+import com.backend.connectable.order.domain.repository.OrderDetailRepository;
+import com.backend.connectable.order.domain.repository.OrderRepository;
+import com.backend.connectable.order.service.OrderService;
+import com.backend.connectable.order.ui.dto.OrderDetailResponse;
+import com.backend.connectable.order.ui.dto.OrderRequest;
+import com.backend.connectable.security.custom.ConnectableUserDetails;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderControllerTest {
+
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean OrderService orderService;
+
+    @Autowired UserRepository userRepository;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OrderDetailRepository orderDetailRepository;
+
+    private static final OrderDetailResponse ORDER_DETAIL_RESPONSE1 =
+            new OrderDetailResponse(
+                    1L,
+                    TicketSalesStatus.PENDING,
+                    null,
+                    10000,
+                    1L,
+                    1L,
+                    1L,
+                    OrderStatus.REQUESTED,
+                    LocalDateTime.now(),
+                    null);
+
+    private static final OrderDetailResponse ORDER_DETAIL_RESPONSE2 =
+            new OrderDetailResponse(
+                    2L,
+                    TicketSalesStatus.PENDING,
+                    null,
+                    10000,
+                    1L,
+                    1L,
+                    2L,
+                    OrderStatus.REQUESTED,
+                    LocalDateTime.now(),
+                    null);
+
+    @BeforeEach
+    void setUp() {
+        orderDetailRepository.deleteAll();
+        orderRepository.deleteAll();
+        userRepository.deleteAll();
+        User user =
+                User.builder()
+                        .klaytnAddress("0x1234")
+                        .nickname("mrlee7")
+                        .phoneNumber("010-2222-3333")
+                        .privacyAgreement(true)
+                        .isActive(true)
+                        .build();
+        userRepository.save(user);
+    }
+
+    @DisplayName("주문 요청시 주문 등록 성공 후 응답한다.")
+    @WithUserDetails("0x1234")
+    @Test
+    void createOrder() throws Exception {
+        // given & when
+        OrderRequest orderRequest =
+                new OrderRequest("이정필", "010-8516-1399", 1L, Arrays.asList(1L, 2L));
+        String json = objectMapper.writeValueAsString(orderRequest);
+
+        // expected
+        mockMvc.perform(post("/orders").contentType(APPLICATION_JSON).content(json))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("유저 정보로 요청시 주문 상세 목록을 반환한다.")
+    @WithUserDetails("0x1234")
+    @Test
+    void getOrderDetailList() throws Exception {
+        // given & when
+        ConnectableUserDetails connectableUserDetails = new ConnectableUserDetails("0x1234");
+        given(orderService.getOrderDetailList(connectableUserDetails))
+                .willReturn(Arrays.asList(ORDER_DETAIL_RESPONSE1, ORDER_DETAIL_RESPONSE2));
+
+        // expected
+        mockMvc.perform(get("/orders/list").contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("주문자명 누락시 ConnectableException 발생하여 주문에 실패한다.")
+    @WithUserDetails("0x1234")
+    @Test
+    void createOrderFailDueToEmptyOrderer() throws Exception {
+        // given & when
+        OrderRequest orderRequest =
+                new OrderRequest("", "010-8516-1399", 1L, Arrays.asList(1L, 2L));
+        String json = objectMapper.writeValueAsString(orderRequest);
+
+        // expected
+        mockMvc.perform(post("/orders").contentType(APPLICATION_JSON).content(json))
+                .andExpect(status().is4xxClientError())
+                .andDo(print());
+    }
+
+    @DisplayName("입금자 연락처 누락시 ConnectableException 발생하여 주문에 실패한다.")
+    @WithUserDetails("0x1234")
+    @Test
+    void createOrderFailDueToEmptyPhoneNumber() throws Exception {
+        // given & when
+        OrderRequest orderRequest =
+                new OrderRequest("", "010-2222-3333", 1L, Arrays.asList(1L, 2L));
+        String json = objectMapper.writeValueAsString(orderRequest);
+
+        // expected
+        mockMvc.perform(post("/orders").contentType(APPLICATION_JSON).content(json))
+                .andExpect(status().is4xxClientError())
+                .andDo(print());
+    }
+
+    @DisplayName("입금자 연락처 규격외 형식 ConnectableException 발생하여 주문에 실패한다.")
+    @WithUserDetails("0x1234")
+    @Test
+    void createOrderFailDueToOutOfStylePhoneNumber() throws Exception {
+        // given & when
+        OrderRequest orderRequest = new OrderRequest("", "01022223333", 1L, Arrays.asList(1L, 2L));
+        String json = objectMapper.writeValueAsString(orderRequest);
+
+        // expected
+        mockMvc.perform(post("/orders").contentType(APPLICATION_JSON).content(json))
+                .andExpect(status().is4xxClientError())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/backend/connectable/security/custom/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/backend/connectable/security/custom/JwtAuthenticationFilterTest.java
@@ -2,7 +2,8 @@ package com.backend.connectable.security.custom;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 import com.backend.connectable.security.exception.ConnectableSecurityException;
 import java.io.IOException;


### PR DESCRIPTION
## 작업 내용
- Order 쪽 Controller 테스트가 부족한 듯 하여 추가했습니다.
- WithUserDetails를 사용하여 임의의 UserDetails를 가져와 사용할 수 있도록 하였습니다.
  - 필요한 Bean 들을 쉽게 가져오려고 AutoConfigureMvc, SpringBootTest를 사용하였습니다. 
  - ControllerTest 에서는 User 객체를 쉽게 반환할 수 있어 WithUserDetails가 좋은 것 같아요 ㅎㅎ( 셋업에서 간단하게 유저 등록 후 사용할 수 있기에 )
 
**참고**
- [Spring Security가 적용된 곳을 효율적으로 테스트하자](https://tecoble.techcourse.co.kr/post/2020-09-30-spring-security-test/)
- [Testing Method Security](https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/test-method.html)
## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
