### PR TITLE
build: jacoco 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
 	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id "com.diffplug.spotless" version "6.10.0"
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.backend'
@@ -50,6 +51,39 @@ allprojects {
 
 test {
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
+}
+
+
+jacoco {
+	toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+	reports {
+		html.enabled true
+	}
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	def Qdomains = []
+	for (qPattern in '*.QA'..'*.QZ') {
+		Qdomains.add(qPattern + '*')
+	}
+
+	violationRules {
+		rule {
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.8
+			}
+
+			excludes = [
+			] + Qdomains
+		}
+	}
 }
 
 tasks.jar {


### PR DESCRIPTION
## 작업 내용
- **Jacoco를 도입합니다**
    - Line Coverage 80%를 못넘기면 테스트가 실패하도록 -> 빌드가 실패하도록 구성했습니다. (현재 라인 커버리지 84%)
    - 점진적으로 커버리지 올라가면 빌드 하한선을 높여가면 될 것 같네요. 
    - 빌드하시고 build/reports/jacoco/test/html/index.html 에 들어가시면 리포트 볼 수 있습니다. (혹시 리포트 path를 바꾸고 싶으시다거나, csv/xml 리포트가 필요하다고 생각하시면 얘기해주세요!) 
    - Qdomain의 경우 커버리지 계산에서 제외했습니다!

## 주의 사항
- *참고: https://techblog.woowahan.com/2661/*

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
