### PR TITLE
test: 어드민 인수테스트 작성

### DIFF
--- a/src/main/java/com/backend/connectable/admin/ui/AdminController.java
+++ b/src/main/java/com/backend/connectable/admin/ui/AdminController.java
@@ -5,6 +5,7 @@ import com.backend.connectable.admin.ui.dto.EventIssueRequest;
 import com.backend.connectable.admin.ui.dto.TokenIssueRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,13 +41,13 @@ public class AdminController {
     public ResponseEntity<Void> deployEvent(
             @Valid @RequestBody EventIssueRequest eventIssueRequest) {
         adminService.issueEvent(eventIssueRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/mint-tokens")
     public ResponseEntity<Void> mintTokens(
             @Valid @RequestBody TokenIssueRequest tokenIssueRequest) {
         adminService.issueTokens(tokenIssueRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/test/java/com/backend/connectable/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/AdminAcceptanceTest.java
@@ -1,0 +1,283 @@
+package com.backend.connectable.acceptance;
+
+import static com.backend.connectable.fixture.ArtistFixture.createArtistBigNaughty;
+import static com.backend.connectable.fixture.EventFixture.createEventValidContractAddressMockedKas;
+import static com.backend.connectable.fixture.TicketFixture.createTicket;
+import static com.backend.connectable.fixture.UserFixture.createUserJoel;
+import static com.backend.connectable.fixture.UserFixture.createUserMrLee;
+import static com.backend.connectable.kas.service.mockserver.KasMockRequest.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.backend.connectable.admin.ui.dto.EventIssueRequest;
+import com.backend.connectable.admin.ui.dto.TokenIssueRequest;
+import com.backend.connectable.artist.domain.Artist;
+import com.backend.connectable.artist.domain.repository.ArtistRepository;
+import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.repository.EventRepository;
+import com.backend.connectable.event.domain.repository.TicketRepository;
+import com.backend.connectable.kas.service.mockserver.KasServiceMockSetup;
+import com.backend.connectable.order.domain.Order;
+import com.backend.connectable.order.domain.OrderDetail;
+import com.backend.connectable.order.domain.OrderStatus;
+import com.backend.connectable.order.domain.repository.OrderDetailRepository;
+import com.backend.connectable.order.domain.repository.OrderRepository;
+import com.backend.connectable.security.custom.JwtProvider;
+import com.backend.connectable.user.domain.User;
+import com.backend.connectable.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("local")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AdminAcceptanceTest extends KasServiceMockSetup {
+
+    @LocalServerPort public int port;
+
+    @Autowired protected OrderDetailRepository orderDetailRepository;
+
+    @Autowired protected UserRepository userRepository;
+
+    @Autowired protected EventRepository eventRepository;
+
+    @Autowired protected TicketRepository ticketRepository;
+
+    @Autowired protected ArtistRepository artistRepository;
+
+    @Autowired protected OrderRepository orderRepository;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Value("${jwt.admin-payload}")
+    private String adminPayload;
+
+    @Autowired private JwtProvider jwtProvider;
+
+    User mrLee = createUserMrLee();
+    User joel = createUserJoel();
+
+    Artist bigNaughty = createArtistBigNaughty();
+    Event bigNaughtyEvent = createEventValidContractAddressMockedKas(bigNaughty);
+
+    Ticket bigNaughtyEventTicket1 = createTicket(bigNaughtyEvent, 1);
+    Ticket bigNaughtyEventTicket2 = createTicket(bigNaughtyEvent, 2);
+
+    Order joelOrder;
+
+    OrderDetail joelOrderDetail1;
+    OrderDetail joelOrderDetail2;
+
+    @BeforeEach
+    void setUpData() {
+        userRepository.saveAll(Arrays.asList(mrLee, joel));
+        artistRepository.save(bigNaughty);
+        eventRepository.save(bigNaughtyEvent);
+        ticketRepository.saveAll(Arrays.asList(bigNaughtyEventTicket1, bigNaughtyEventTicket2));
+        makeJoelOrder();
+    }
+
+    private void makeJoelOrder() {
+        joelOrder =
+                Order.builder()
+                        .user(joel)
+                        .ordererName("조영상")
+                        .ordererPhoneNumber("010-0000-0000")
+                        .build();
+        joelOrderDetail1 = new OrderDetail(OrderStatus.REQUESTED, null, bigNaughtyEventTicket1);
+        joelOrderDetail2 = new OrderDetail(OrderStatus.REQUESTED, null, bigNaughtyEventTicket2);
+        joelOrder.addOrderDetails(List.of(joelOrderDetail1, joelOrderDetail2));
+        orderRepository.save(joelOrder);
+    }
+
+    @DisplayName("어드민 토큰을 활용하여 order-detail을 paid -> transfer_success로 변경할 수 있다.")
+    @Test
+    void orderDetailToPaid() {
+        // when
+        ExtractableResponse<Response> response = 어드민_오더_상세_PAID_변경(joelOrderDetail1.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        OrderDetail modifiedOrderDetail =
+                orderDetailRepository.findById(joelOrderDetail1.getId()).get();
+        assertThat(modifiedOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.TRANSFER_SUCCESS);
+    }
+
+    @DisplayName("어드민 토큰을 활용하여 order-detail을 unpaid로 변경할 수 있다.")
+    @Test
+    void orderDetailToUnpaid() {
+        // when
+        ExtractableResponse<Response> response = 어드민_오더_상세_UNPAID_변경(joelOrderDetail1.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        OrderDetail modifiedOrderDetail =
+                orderDetailRepository.findById(joelOrderDetail1.getId()).get();
+        assertThat(modifiedOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.UNPAID);
+    }
+
+    @DisplayName("어드민 토큰을 활용하여 order-detail을 refund로 변경할 수 있다.")
+    @Test
+    void orderDetailToRefund() {
+        // when
+        ExtractableResponse<Response> response = 어드민_오더_상세_REFUND_변경(joelOrderDetail1.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        OrderDetail modifiedOrderDetail =
+                orderDetailRepository.findById(joelOrderDetail1.getId()).get();
+        assertThat(modifiedOrderDetail.getOrderStatus()).isEqualTo(OrderStatus.REFUND);
+    }
+
+    @DisplayName("어드민 토큰을 활용해 이벤트를 발행할 수 있다.")
+    @Test
+    void deployEvent() {
+        // given
+        long eventCountBefore = eventRepository.count();
+        EventIssueRequest eventIssueRequest =
+                new EventIssueRequest(
+                        "Contract",
+                        "CON",
+                        VALID_ALIAS,
+                        "인수 이벤트",
+                        "인수 이벤트 설명",
+                        "https://image.url",
+                        "https://twitter.url",
+                        "https://instagram.url",
+                        "https://webpage.url",
+                        "인수 이벤트 위치",
+                        bigNaughty.getId(),
+                        LocalDateTime.of(2000, 1, 1, 0, 0, 0),
+                        LocalDateTime.of(2001, 1, 1, 0, 0, 0),
+                        LocalDateTime.of(2002, 1, 1, 0, 0, 0),
+                        LocalDateTime.of(2003, 1, 1, 0, 0, 0));
+
+        // when
+        ExtractableResponse<Response> response = 어드민_이벤트_발행(eventIssueRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        long eventCountAfter = eventRepository.count();
+        assertThat(eventCountAfter - eventCountBefore).isEqualTo(1L);
+    }
+
+    @DisplayName("어드민 토큰을 통해 이벤트의 토큰을 민팅할 수 있다.")
+    @Test
+    void minTokens() {
+        // given
+        String validTokenUri =
+                "https://connectable-events.s3.ap-northeast-2.amazonaws.com/brown-event/json/1.json";
+        TokenIssueRequest tokenIssueRequest =
+                new TokenIssueRequest(
+                        VALID_CONTRACT_ADDRESS,
+                        VALID_TOKEN_ID_BY_INT,
+                        VALID_TOKEN_ID_BY_INT,
+                        validTokenUri,
+                        10000);
+
+        // when
+        ExtractableResponse<Response> response = 어드민_토큰_발행(tokenIssueRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private ExtractableResponse<Response> 어드민_오더_상세_PAID_변경(Long orderDetailId) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .when()
+                .auth()
+                .oauth2(generateAdminToken())
+                .patch("/admin/order-details/{order-detail-id}/paid", orderDetailId)
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 어드민_오더_상세_UNPAID_변경(Long orderDetailId) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .when()
+                .auth()
+                .oauth2(generateAdminToken())
+                .patch("/admin/order-details/{order-detail-id}/unpaid", orderDetailId)
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 어드민_오더_상세_REFUND_변경(Long orderDetailId) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .when()
+                .auth()
+                .oauth2(generateAdminToken())
+                .patch("/admin/order-details/{order-detail-id}/refund", orderDetailId)
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 어드민_이벤트_발행(EventIssueRequest eventIssueRequest) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .when()
+                .auth()
+                .oauth2(generateAdminToken())
+                .body(eventIssueRequest)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .post("/admin/deploy-event")
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 어드민_토큰_발행(TokenIssueRequest tokenIssueRequest) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .when()
+                .auth()
+                .oauth2(generateAdminToken())
+                .body(tokenIssueRequest)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .post("/admin/mint-tokens")
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    private String generateAdminToken() {
+        return jwtProvider.generateToken(adminPayload);
+    }
+}

--- a/src/test/java/com/backend/connectable/fixture/EventFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/EventFixture.java
@@ -3,6 +3,7 @@ package com.backend.connectable.fixture;
 import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.SalesOption;
+import com.backend.connectable.kas.service.mockserver.KasMockRequest;
 import java.time.LocalDateTime;
 
 public class EventFixture {
@@ -15,6 +16,25 @@ public class EventFixture {
                 .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
                 .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
                 .contractAddress("0x5555aaaa")
+                .eventName("콘서트")
+                .eventImage("EVENT_IMG_URL")
+                .twitterUrl("https://github.com/joelonsw")
+                .instagramUrl("https://www.instagram.com/jyoung_with/")
+                .webpageUrl("https://papimon.tistory.com/")
+                .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+                .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+                .salesOption(SalesOption.FLAT_PRICE)
+                .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
+                .artist(artist)
+                .build();
+    }
+
+    public static Event createEventValidContractAddressMockedKas(Artist artist) {
+        return Event.builder()
+                .description("콘서트 at Connectable")
+                .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+                .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+                .contractAddress(KasMockRequest.VALID_CONTRACT_ADDRESS)
                 .eventName("콘서트")
                 .eventImage("EVENT_IMG_URL")
                 .twitterUrl("https://github.com/joelonsw")


### PR DESCRIPTION
## 작업 내용
1. **어드민 인수테스트를 작성합니다**
    - 테스트 하기 까다로운 Kas의 경우, Netty Mockserver를 통해 구현해둔 KasServiceMockSetup 클래스를 재활용하여 구현합니다. 
    - 외부모듈이 많아질 수록 테스트하기가 참 어렵다는걸 많이 느끼네요. 
     - <img width="670" alt="스크린샷 2022-10-09 오후 3 35 19" src="https://user-images.githubusercontent.com/61370901/194741808-2db5c63c-e630-481d-be25-22bdc1014642.png">


## 주의 사항
- 다양한 로직과 기능들이 섞여있는 Admin 이다보니 인수테스트를 작성하면서 몇가지 문제점이 눈에 띄었습니다. 
- SmsService의 경우 테스트 코드에 유효한 핸드폰 번호를 입력했을때, 진짜 문자가 가는 상황이 발생하더라고요. 
- 지금은 테스트 코드에 유효하지 않은 번호를 기입해뒀기 때문에 누군가가 문자를 받진 않겠지만, 테스트 코드를 돌릴때 마다 누리고에서 해당 번호로 문자 보내고 문자 50원이 차감되지는 않나 걱정이되더라고요. 
- 따라서 테스트에서는 진짜 SmsService를 쓰지 않도록 테스트 코드 개선이 필요해보입니다. 
- 생각나는 방법이 몇가지 있긴한데요. 
    1. SmsService가 들어가는 모든 테스트코드에 MockBean 설정하기
    2. SmsService를 인터페이스화 시켜서, 테스트에서만 사용할 SmsService 구현체를 만들어 테스트 진행하기
    3. Bean으로 생성하는 SmsConfig내의 DefaultMessageService의 경우, 너무 누리고 서비스에 의존적인 Bean 구현 같다는 생각도 듦. MessageService를 새로 만들어 DefaultMessageService를 필드로 가지게 하는 방식으로 리팩터링도 가능해보임. 이러면 MessageService를 또 새롭게 테스트에서만 사용할 구현체로 구현할 수도 있어보임 (이게 말로 설명하는게 좀 어려워서 필요하면 라이브코딩 해볼수도 있을듯합니다!)
- 쨋든 SmsService 리팩터링 방향에 대해 생각해봅시다!

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
