### PR TITLE
fix: Request key 이슈로 에러나는 현상 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 * Spring Boot 2.7.1
 * MySQL 8.0.28
 * Redis
-* AWS EC2 (Ubuntu 18.04) 
+* AWS EC2 (Ubuntu 18.04)
 * AWS RDS MySQL
-* AWS S3 
+* AWS S3
 * AWS SSM
 * Jenkins FreeStyle

--- a/src/test/java/com/backend/connectable/acceptance/UserAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/UserAcceptanceTest.java
@@ -1,9 +1,16 @@
 package com.backend.connectable.acceptance;
 
+import static com.backend.connectable.fixture.KlipFixture.getRequestKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.backend.connectable.klip.service.KlipService;
+import com.backend.connectable.klip.service.dto.KlipAuthLoginResponse;
 import com.backend.connectable.user.ui.dto.UserLoginRequest;
 import com.backend.connectable.user.ui.dto.UserLoginSuccessResponse;
 import com.backend.connectable.user.ui.dto.UserModifyRequest;
 import com.backend.connectable.user.ui.dto.UserResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -11,31 +18,38 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("local")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class UserAcceptanceTest {
 
-    @LocalServerPort
-    public int port;
+    @LocalServerPort public int port;
+
+    @MockBean protected KlipService klipService;
+
+    private String requestKey;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws JsonProcessingException {
         RestAssured.port = port;
+
+        requestKey = getRequestKey();
+        KlipAuthLoginResponse klipAuthLoginResponse =
+                KlipAuthLoginResponse.ofCompleted("0x9f3c619b6f534d123c8fc35607d73eee0161da7b");
+        given(klipService.authLogin(requestKey)).willReturn(klipAuthLoginResponse);
     }
 
     @DisplayName("requestKey를 이용하여 유저 로그인 시 유저 정보가 등록된다.")
     @Test
     void successUserLogin() {
         // given
-        UserLoginRequest 유저_가입_요청 = new UserLoginRequest("95323c1e-c6a5-4a91-8f99-8593f7d70a4f");
+        UserLoginRequest 유저_가입_요청 = new UserLoginRequest(requestKey);
 
         // when
         ExtractableResponse<Response> 유저_등록_성공후_응답 = 유저정보를_등록한다(유저_가입_요청);
@@ -48,12 +62,13 @@ public class UserAcceptanceTest {
     @Test
     void successUpdateMyProfile() {
         // given
-        UserLoginRequest 유저_가입_요청 = new UserLoginRequest("95323c1e-c6a5-4a91-8f99-8593f7d70a4f");
+        UserLoginRequest 유저_가입_요청 = new UserLoginRequest(requestKey);
         UserModifyRequest 유저_수정_요청 = new UserModifyRequest("mrlee7", "010-8516-1399");
 
         // when
         ExtractableResponse<Response> 유저_등록_성공후_응답 = 유저정보를_등록한다(유저_가입_요청);
-        UserLoginSuccessResponse userLoginSuccessResponse = 유저_등록_성공후_응답.as(UserLoginSuccessResponse.class);
+        UserLoginSuccessResponse userLoginSuccessResponse =
+                유저_등록_성공후_응답.as(UserLoginSuccessResponse.class);
         String 등록된_유저_토큰 = userLoginSuccessResponse.getJwt();
 
         ExtractableResponse<Response> 유저_수정_성공후_응답 = 유저정보를_수정한다(유저_수정_요청, 등록된_유저_토큰);
@@ -80,39 +95,60 @@ public class UserAcceptanceTest {
     }
 
     private static ExtractableResponse<Response> 유저정보를_등록한다(UserLoginRequest userLoginRequest) {
-        return RestAssured.given().log().all()
-            .contentType("application/json")
-            .body(userLoginRequest)
-            .when().post("/users/login")
-            .then().log().all()
-            .extract();
+        return RestAssured.given()
+                .log()
+                .all()
+                .contentType("application/json")
+                .body(userLoginRequest)
+                .when()
+                .post("/users/login")
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
-    private static ExtractableResponse<Response> 유저정보를_수정한다(UserModifyRequest userModifyRequest, String token) {
-        return RestAssured.given().log().all()
-            .header("Authorization", "Bearer " + token)
-            .contentType("application/json")
-            .body(userModifyRequest)
-            .when().put("/users")
-            .then().log().all()
-            .extract();
+    private static ExtractableResponse<Response> 유저정보를_수정한다(
+            UserModifyRequest userModifyRequest, String token) {
+        return RestAssured.given()
+                .log()
+                .all()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(userModifyRequest)
+                .when()
+                .put("/users")
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
     private static ExtractableResponse<Response> 유저정보를_조회한다(String token) {
-        return RestAssured.given().log().all()
-            .header("Authorization", "Bearer " + token)
-            .contentType("application/json")
-            .when().get("/users")
-            .then().log().all()
-            .extract();
+        return RestAssured.given()
+                .log()
+                .all()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .when()
+                .get("/users")
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
     private static ExtractableResponse<Response> 사용가능한_닉네임_여부_조회한다(String nickname) {
-        return RestAssured.given().log().all()
-            .contentType("application/json")
-            .param("nickname", nickname)
-            .when().get("/users/validation")
-            .then().log().all()
-            .extract();
+        return RestAssured.given()
+                .log()
+                .all()
+                .contentType("application/json")
+                .param("nickname", nickname)
+                .when()
+                .get("/users/validation")
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 }

--- a/src/test/java/com/backend/connectable/fixture/KlipFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/KlipFixture.java
@@ -1,0 +1,37 @@
+package com.backend.connectable.fixture;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
+
+public class KlipFixture {
+
+    private KlipFixture() {}
+
+    public static String getRequestKey() throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+
+        RequestKeyRequest requestKeyRequest = new RequestKeyRequest("CONNECTABLE", "auth");
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        HttpEntity<String> request =
+                new HttpEntity<>(objectMapper.writeValueAsString(requestKeyRequest), headers);
+
+        RequestKeyResponse requestKeyResponse =
+                restTemplate.postForObject(
+                        "https://a2a-api.klipwallet.com/v2/a2a/prepare",
+                        request,
+                        RequestKeyResponse.class);
+
+        return requestKeyResponse.getRequestKey();
+    }
+}

--- a/src/test/java/com/backend/connectable/fixture/RequestKeyRequest.java
+++ b/src/test/java/com/backend/connectable/fixture/RequestKeyRequest.java
@@ -1,0 +1,23 @@
+package com.backend.connectable.fixture;
+
+public class RequestKeyRequest {
+
+    private BappRequest bapp;
+    private String type;
+
+    private RequestKeyRequest() {}
+
+    public RequestKeyRequest(String name, String type) {
+        this.bapp = new BappRequest(name);
+        this.type = type;
+    }
+}
+
+class BappRequest {
+
+    private String name;
+
+    public BappRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/com/backend/connectable/fixture/RequestKeyResponse.java
+++ b/src/test/java/com/backend/connectable/fixture/RequestKeyResponse.java
@@ -1,0 +1,28 @@
+package com.backend.connectable.fixture;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class RequestKeyResponse {
+
+    private RequestKeyResponse() {}
+
+    private String requestKey;
+
+    private String status;
+
+    private Long expirationTime;
+
+    public String getRequestKey() {
+        return requestKey;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Long getExpirationTime() {
+        return expirationTime;
+    }
+}

--- a/src/test/java/com/backend/connectable/user/ui/UserControllerTest.java
+++ b/src/test/java/com/backend/connectable/user/ui/UserControllerTest.java
@@ -1,7 +1,7 @@
 package com.backend.connectable.user.ui;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.backend.connectable.event.domain.TicketSalesStatus;
+import com.backend.connectable.fixture.KlipFixture;
 import com.backend.connectable.security.custom.ConnectableUserDetails;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
@@ -76,8 +77,8 @@ class UserControllerTest {
     @Test
     void loginUserSuccess() throws Exception {
         // given & when
-        UserLoginRequest userLoginRequest =
-                new UserLoginRequest("95323c1e-c6a5-4a91-8f99-8593f7d70a4f");
+        String requestKey = KlipFixture.getRequestKey();
+        UserLoginRequest userLoginRequest = new UserLoginRequest(requestKey);
         String json = objectMapper.writeValueAsString(userLoginRequest);
 
         mockMvc.perform(post("/users/login").contentType(APPLICATION_JSON).content(json))


### PR DESCRIPTION
## 작업 내용
- Request key가 유효하지 않은 경우 네트워크 에러 발생 현상 수정
  - KlipFixture에서 RestTemplate으로 Klip API '/prepare' 엔드포인트 호출후 응답 반환

## 주의 사항
- 기존 시나리오에서는 request-key로 생성된 QR코드를 찍어야 status 가 prepared -> requested -> completed로 넘어감
- 테스트 코드에서 KlipService.authLogin에서 QR인증이 되지 않은 request key에 대해 jwt를 내려주지 않아 임의로 모킹함
- 필드명 SNAKE_CASE <-> camelCase 불일치 이슈(응답값이 null로 받아짐)로 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class) 사용
  - 더 좋은 방법이 있다면 코멘트 부탁드립니다 :)  

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
