### PR TITLE
feat: TimeCheck AOP 도입

### DIFF
--- a/src/main/java/com/backend/connectable/global/aop/MethodNameExtractor.java
+++ b/src/main/java/com/backend/connectable/global/aop/MethodNameExtractor.java
@@ -1,0 +1,14 @@
+package com.backend.connectable.global.aop;
+
+import org.aspectj.lang.Signature;
+
+public class MethodNameExtractor {
+    private MethodNameExtractor() {}
+
+    public static String generate(Signature joinPointSignature) {
+        return joinPointSignature.getDeclaringTypeName()
+                + "."
+                + joinPointSignature.getName()
+                + "()";
+    }
+}

--- a/src/main/java/com/backend/connectable/global/aop/TimeCheck.java
+++ b/src/main/java/com/backend/connectable/global/aop/TimeCheck.java
@@ -1,0 +1,12 @@
+package com.backend.connectable.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeCheck {
+    long warningThreshold() default 1000;
+}

--- a/src/main/java/com/backend/connectable/global/aop/TimeCheckAspect.java
+++ b/src/main/java/com/backend/connectable/global/aop/TimeCheckAspect.java
@@ -1,0 +1,29 @@
+package com.backend.connectable.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Aspect
+@Configuration
+public class TimeCheckAspect {
+
+    @Around("@annotation(timeCheck)")
+    public Object checkTime(ProceedingJoinPoint joinPoint, TimeCheck timeCheck) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long endTime = System.currentTimeMillis();
+
+        long timeTaken = endTime - startTime;
+        String methodName = MethodNameExtractor.generate(joinPoint.getSignature());
+        log.info("timeTaken : {} at method {}", timeTaken, methodName);
+
+        if (timeTaken > timeCheck.warningThreshold()) {
+            log.warn("$$ TimeCheck Expired at = {} $$", methodName);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/backend/connectable/kas/service/KasService.java
+++ b/src/main/java/com/backend/connectable/kas/service/KasService.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.kas.service;
 
+import com.backend.connectable.global.aop.TimeCheck;
 import com.backend.connectable.kas.service.common.dto.TransactionResponse;
 import com.backend.connectable.kas.service.contract.KasContractService;
 import com.backend.connectable.kas.service.contract.dto.ContractDeployResponse;
@@ -93,6 +94,7 @@ public class KasService {
         return kasTokenService.getTokenHistory(contractAddress, tokenId);
     }
 
+    @TimeCheck
     public Map<String, TokensResponse> findAllTokensOwnedByUser(
             List<String> contractAddresses, String userKlaytnAddress) {
         return kasTokenService.findAllTokensOwnedByUser(contractAddresses, userKlaytnAddress);


### PR DESCRIPTION
## 작업 내용
1. **AOP를 공부했습니다**
    - 사실 AOP에 대한 이해가 많이 부족했습니다. AOP의 필요성에 대해서 입문하기 좋았던 글 첨부합니다. (https://tecoble.techcourse.co.kr/post/2021-06-25-aop-transaction/)
    - 어쨋든 이 횡단 관심사를 그냥 OOP 방식으로 기능 구현하듯이 만들 수는 있겠지만, 오히려 재사용성이 떨어지는 일이 발생하는데요. 따라서 횡단 관심사를 처리할 수 있도록 AOP라는 기술을 씁니다. 
    - 자바에서 AOP를 쓸라면 프록시라는 기술을 써야합니다. 
    - 프록시는 실제 요청을 처리할 객체를 인스턴스 변수로 가지고 있고, 요청을 처리하기 전/후로 필요한 전처리/후처리를 진행하는 방식입니다. 
    - 프록시는 리플렉션들과 같은 자바 고급기술들을 휘뚜루마뚜루 적용시켜 뚝딱 만드는데요. 크게 2가지 방식이 있습니다. 
        - JdkDynamicProxy : 인터페이스가 있는 경우 쓸 수 있음 (자바 언어 내장기술)
        - CGLIB : 구체 클래스를 상속받아서 만듦 (외부 라이브러리. 근데 스프링부트2.0 부터 디폴트로 이거 채택함)
    - 이렇게 횡단 관심사 로직이 필요한 메서드가 포함된 빈에 대해서는, 어플리케이션 컨텍스트에 등록하기전에 해당 빈을 프록시화 하여 빈을 등록하게 됩니다. 
        - 여기( https://github.com/joelonsw/TIL/blob/master/2022-10/2022-10-17.md#kasservice%EC%97%90-aop-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0 )에 1,2번을 보시면 제가 정의한 `@TimeCheck`를 붙이지 않았을 때와 붙였을 때 어플리케이션 컨텍스트에서 KasService를 어떻게 등록하는지를 확인하실 수 있습니다. 
          - 프록시화가 필요하다면(그니까 AOP로직이 있다면) CGLIB을 통해 프록시화 시켜 등록하는 것을 알 수 있고, 
          - 프록시가 굳이 필요없다면(그니까 전/후처리 필요없다면) 빈 그 자체를 등록시키는 것을 알 수 있습니다. 

2. **global/aop 패키지에서 TimeCheck 어노테이션을 활용해 AOP를 적용합니다.**
    - TimeCheck 어노테이션은 메서드에 붙일 수 있어요. 기본적인 기능은 해당 어노테이션이 붙은 메서드가 실행될 때 시간이 얼마나 걸리는지 검사합니다. 
      - 1000ms 초과하면 warn 로그 띄우게 기본 설정해뒀습니다. 어노테이션 자체의 warningThreshold 값으로 이를 바꿀 수도 있습니다
      - 해당 어노테이션이 붙어있다면, 스프링님 proxy 객체를 만들어 처리해주세요~ 라는 걸 TimeCheckAspect에서 설정해주게 됩니다. 
    - 살짝 설명을 곁들인 주석을 같이 올려드립니다. 용어가 생소해서 낯설었습니다. 제 TIL을 보시고 해당 클래스를 보시면 이해에 더 도움되실 수 있습니다. (https://github.com/joelonsw/TIL/blob/master/2022-10/2022-10-17.md)
    ```java
    @Slf4j
    @Aspect // 해당 어노테이션을 통해 편리하게 **포인트컷**(어디에 대해 프록시를 적용하는지) + **어드바이스**(무슨 로직을 전/후처리로 진행할건지)로 구성된 어드바이저를 생성한다. 
    @Configuration
    public class TimeCheckAspect {
    
        @Around("@annotation(timeCheck)") // Around는 메서드 전/후로 필요한 로직을 실행한다는 뜻. 안에 "@annotation(timeCheck)"는 timeCheck 어노테이션이 붙은 메서드에 대해 프록시를 적용한다는 정의 (포인트컷)
        public Object checkTime(ProceedingJoinPoint joinPoint, TimeCheck timeCheck) throws Throwable {
            long startTime = System.currentTimeMillis();
            Object result = joinPoint.proceed(); // 실제 객체에게 실행을 시킴. 
            long endTime = System.currentTimeMillis();
    
            long timeTaken = endTime - startTime;
            String methodName = MethodNameExtractor.generate(joinPoint.getSignature());
            log.info("timeTaken : {} at method {}", timeTaken, methodName);
    
            if (timeTaken > timeCheck.warningThreshold()) {
                log.warn("$$ TimeCheck Expired at = {} $$", methodName);
            }
            return result; // 후처리 다~ 하고 값 반환
        }
    }
    ```

## 주의 사항
- 프록시라는 말... 많이 쓰잖습니까? 그게 다 뜻하는바가 똑같더군요
    - nginx를 통해 리버스 프록시를 구축한다라는 말을 하는데, 결국 동적인 처리를 was에게 맡기는데, nginx가 필요한 전처리(가령 정적 파일 반환이라든지) 후처리(캐싱을 해둔다던지) 이런걸 앞단에서 클라이언트는 모르게 쓱 처리하는게 다 프록시더군요
    - 이제 프록시라는 말을 들으면 위임할 친구는 따로 두고, 그 앞단에서 필요한 전/후처리를 진행한다 라는 그림을 먼저 떠올릴 수 있을 것 같습니다. 

- 우리가 자주쓰는 Transactional 어노테이션 있잖습니까? 그것도 AOP를 활용합니다. 
    - 결국 해당 메서드가 원자적으로 잘 동작하면 commit, 뻑나면 rollback을 해야지요?
    - 이런 공통된 로직을 AOP 기술을 통하면 횡단 관심사로 뺄 수 있을 겁니다. 마치 TimeCheck 처럼요!

- 코드에 적용할 더 좋은 네이밍이 있다면 알려주십쇼~!

+) 이찬혁 앨범 나왔는데 전곡 다 좋습니다 오늘 앨범 10번째 듣고있네요

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
