### PR TITLE
refactor: DirtiesContext제거 하여 Truncate로 변경

### DIFF
--- a/src/test/java/com/backend/connectable/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/AdminAcceptanceTest.java
@@ -40,11 +40,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("local")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AdminAcceptanceTest extends KasServiceMockSetup {
 
@@ -62,9 +60,12 @@ class AdminAcceptanceTest extends KasServiceMockSetup {
 
     @Autowired protected OrderRepository orderRepository;
 
+    @Autowired private DatabaseCleanUp databaseCleanUp;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        databaseCleanUp.execute();
     }
 
     @Value("${jwt.admin-payload}")

--- a/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/backend/connectable/acceptance/AuthAcceptanceTest.java
@@ -6,13 +6,12 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("local")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthAcceptanceTest {
 
@@ -21,9 +20,12 @@ public class AuthAcceptanceTest {
 
     @LocalServerPort public int port;
 
+    @Autowired private DatabaseCleanUp databaseCleanUp;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        databaseCleanUp.execute();
     }
 
     @DisplayName("요청하여 응답받은 인증키를 이용하여 인증시 성공한다")

--- a/src/test/java/com/backend/connectable/acceptance/DatabaseCleanUp.java
+++ b/src/test/java/com/backend/connectable/acceptance/DatabaseCleanUp.java
@@ -1,0 +1,67 @@
+package com.backend.connectable.acceptance;
+
+import com.google.common.base.CaseFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+@Component
+@ActiveProfiles("local")
+public class DatabaseCleanUp implements InitializingBean {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        tableNames =
+                entityManager.getMetamodel().getEntities().stream()
+                        .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                        .filter(e -> e.getJavaType().getAnnotation(Table.class) == null)
+                        .map(
+                                e ->
+                                        CaseFormat.UPPER_CAMEL.to(
+                                                CaseFormat.LOWER_UNDERSCORE, e.getName()))
+                        .collect(Collectors.toList());
+        List<String> tableNamesWithAnnotation =
+                entityManager.getMetamodel().getEntities().stream()
+                        .filter(e -> e.getJavaType().getAnnotation(Table.class) != null)
+                        .map(
+                                e ->
+                                        CaseFormat.UPPER_CAMEL.to(
+                                                CaseFormat.LOWER_UNDERSCORE,
+                                                e.getJavaType().getAnnotation(Table.class).name()))
+                        .collect(Collectors.toList());
+        tableNames.addAll(tableNamesWithAnnotation);
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        tableNames.stream()
+                .forEach(
+                        tableName -> {
+                            entityManager
+                                    .createNativeQuery("TRUNCATE TABLE " + tableName)
+                                    .executeUpdate();
+                            entityManager
+                                    .createNativeQuery(
+                                            "ALTER TABLE "
+                                                    + tableName
+                                                    + " ALTER COLUMN ID RESTART WITH 1")
+                                    .executeUpdate();
+                        });
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 인수 테스트 내 DirtiesContext 제거
  - ApplicationContext가 메소드 단위로 재시작 되면서 속도가 느려짐 -> 인수테스트 코드 실행시 평균적으로 70s 소요됨
<img width="467" alt="스크린샷 2022-11-03 오전 2 39 07" src="https://user-images.githubusercontent.com/54073761/199642040-853ee04d-c59a-4e8d-b55d-5b3abd6c724b.png">
  - DB Table Truncate 방식을 이용하여 ApplicationContext 재시작하지 않고 테스트를 위해 데이터 초기화를 진행함 -> 평균 40s 까지 속도 개선 진행 
  
<img width="468" alt="image" src="https://user-images.githubusercontent.com/54073761/199642139-4823b67f-f745-4bb4-a252-c949abeafb9f.png">

## 주의 사항

## 참고
- https://tecoble.techcourse.co.kr/post/2022-10-15-test-code-optimization/

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
