### PR TITLE
feat: 프로메테우스 actuator 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	// DB

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-core'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	// DB
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/backend/connectable/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/backend/connectable/global/config/swagger/SwaggerConfig.java
@@ -85,7 +85,7 @@ public class SwaggerConfig {
             CorsEndpointProperties corsProperties,
             WebEndpointProperties webEndpointProperties,
             Environment environment) {
-        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList<>();
         Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
         allEndpoints.addAll(webEndpoints);
         allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());

--- a/src/main/java/com/backend/connectable/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/backend/connectable/global/config/swagger/SwaggerConfig.java
@@ -1,9 +1,26 @@
 package com.backend.connectable.global.config.swagger;
 
+import static java.util.Collections.singletonList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.*;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -16,12 +33,6 @@ import springfox.documentation.service.Server;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
-
-import static java.util.Collections.singletonList;
-
 @Configuration
 public class SwaggerConfig {
 
@@ -31,43 +42,73 @@ public class SwaggerConfig {
     @Bean
     public Docket parseApi() {
         return new Docket(DocumentationType.OAS_30)
-            .ignoredParameterTypes(AuthenticationPrincipal.class)
-            .servers(serverInfo())
-            .apiInfo(apiInfo())
-            .globalRequestParameters(parameters())
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("com.backend.connectable"))
-            .paths(PathSelectors.ant("/**"))
-            .paths(Predicate.not(PathSelectors.regex("/admin.*")))
-            .build();
+                .ignoredParameterTypes(AuthenticationPrincipal.class)
+                .servers(serverInfo())
+                .apiInfo(apiInfo())
+                .globalRequestParameters(parameters())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.backend.connectable"))
+                .paths(PathSelectors.ant("/**"))
+                .paths(Predicate.not(PathSelectors.regex("/admin.*")))
+                .build();
     }
 
     private List<RequestParameter> parameters() {
         return singletonList(
-            new RequestParameterBuilder()
-                .name("Authorization")
-                .description("Required for user-based requests")
-                .in(ParameterType.HEADER)
-                .required(false)
-                .query(q -> q.model(m -> m.scalarModel(ScalarType.STRING)))
-                .build()
-        );
+                new RequestParameterBuilder()
+                        .name("Authorization")
+                        .description("Required for user-based requests")
+                        .in(ParameterType.HEADER)
+                        .required(false)
+                        .query(q -> q.model(m -> m.scalarModel(ScalarType.STRING)))
+                        .build());
     }
 
     private Server serverInfo() {
-        return new Server("",
-            baseUrl,
-            "",
-            Collections.emptyList(),
-            Collections.emptyList()
-        );
+        return new Server("", baseUrl, "", Collections.emptyList(), Collections.emptyList());
     }
 
     private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-            .title("Connectable API Documentation")
-            .description("API documentation of Connectable project by Team UACC")
-            .version("1.0.0")
-            .build();
+                .title("Connectable API Documentation")
+                .description("API documentation of Connectable project by Team UACC")
+                .version("1.0.0")
+                .build();
+    }
+
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(
+            WebEndpointsSupplier webEndpointsSupplier,
+            ServletEndpointsSupplier servletEndpointsSupplier,
+            ControllerEndpointsSupplier controllerEndpointsSupplier,
+            EndpointMediaTypes endpointMediaTypes,
+            CorsEndpointProperties corsProperties,
+            WebEndpointProperties webEndpointProperties,
+            Environment environment) {
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+        boolean shouldRegisterLinksMapping =
+                this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
+        return new WebMvcEndpointHandlerMapping(
+                endpointMapping,
+                webEndpoints,
+                endpointMediaTypes,
+                corsProperties.toCorsConfiguration(),
+                new EndpointLinksResolver(allEndpoints, basePath),
+                shouldRegisterLinksMapping,
+                null);
+    }
+
+    private boolean shouldRegisterLinksMapping(
+            WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled()
+                && (StringUtils.hasText(basePath)
+                        || ManagementPortType.get(environment)
+                                .equals(ManagementPortType.DIFFERENT));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,15 +5,25 @@ spring:
       local: console-logging
       dev: console-logging,file-sql-logging,file-info-logging,file-error-logging,slack-dev-error-logging,slack-paid-logging
       prod: console-logging,file-sql-logging,file-info-logging,file-error-logging,slack-dev-error-logging,slack-paid-logging
+  application:
+    name: connectable-backend
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+  metrics:
+    tags:
+      application: ${spring.application.name}
 ---
 spring:
   config:
     activate:
       on-profile: local
     import: 'aws-parameterstore:'
-  mvc:
-    pathmatch:
-      matching-strategy: ant_path_matcher
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     activate:
       on-profile: local
     import: 'aws-parameterstore:'
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## 작업 내용
1. **프로메테우스 + 그라파나 모니터링을 위해 코드레벨에서 actuator를 도입합니다**
    - Spring Boot 모니터링/메트릭을 API 형식으로 확인할 수 있도록 지원하는 actuator 의존성, prometheus에 사용될 메트릭 정보를 수집하는 micrometer-registry-prometheus 의존성을 추가합니다. 
    - Springfox (Swagger) 의존성이랑 충돌이 나는 부분이 있어서 이를 해결했습니다. (https://github.com/joelonsw/TIL/blob/master/2022-11/2022-11-05.md#spring-actuator%EC%99%80-springfox-%EC%B6%A9%EB%8F%8C)
    - 해당 pr 머지 이후 dev 환경에서 프로메테우스 + 그라파나 구축을 시도해보겠습니다. 

## 주의 사항
- 우선 현재 설정으로 base_url/actuator에 접근하면 모든 사람들이 저희 서버의 메트릭을 다 볼 수 있어요
    - 해당 url에 대해 인증/인가 로직이 있어야 할 것 같기도합니다...?!
    - 혹시 현업에서 프로메테우스 + 그라파나 쓰실 때 모니터링을 위한 메트릭 조회 url을 막아뒀는지도 궁금합니다. 
- application.yml에 공통된 사항은 그냥 --- 기준 맨 위 블럭으로 옮겨도 될 것 같은데 저희가 프로파일 별로 중복된 것들 그냥 써두긴 했군요. 혹시나 나중에 너무 복잡해지면 리팩터링 해봅시다!

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
