### PR TITLE
feat: 오늘 구매 가능한 이벤트 조회 API

### DIFF
--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface EventRepositoryCustom {
     List<Event> findAllEventWithOrder();
 
     List<Event> findAllEventsByArtistId(Long artistId);
+
+    List<Event> findAllNowAvailable();
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -153,6 +153,13 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     }
 
     @Override
+    public List<Event> findAllNowAvailable() {
+        return queryFactory.selectFrom(event)
+            .where(event.salesTo.after(LocalDateTime.now()))
+            .fetch();
+    }
+
+    @Override
     public List<Event> findAllEventsByArtistId(Long artistId) {
         return queryFactory.selectFrom(event).innerJoin(artist).on(artist.id.eq(artistId)).fetch();
     }

--- a/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/EventRepositoryImpl.java
@@ -154,9 +154,10 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
 
     @Override
     public List<Event> findAllNowAvailable() {
-        return queryFactory.selectFrom(event)
-            .where(event.salesTo.after(LocalDateTime.now()))
-            .fetch();
+        return queryFactory
+                .selectFrom(event)
+                .where(event.salesTo.after(LocalDateTime.now()))
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -42,6 +42,13 @@ public class EventService {
                 .collect(Collectors.toList());
     }
 
+    public List<EventResponse> getListNowAvailable() {
+        List<Event> events = eventRepository.findAllNowAvailable();
+        return events.stream()
+            .map(EventMapper.INSTANCE::eventToResponse)
+            .collect(Collectors.toList());
+    }
+
     public EventDetailResponse getEventDetail(Long eventId) {
         EventDetail eventDetail =
                 eventRepository

--- a/src/main/java/com/backend/connectable/event/service/EventService.java
+++ b/src/main/java/com/backend/connectable/event/service/EventService.java
@@ -45,8 +45,8 @@ public class EventService {
     public List<EventResponse> getListNowAvailable() {
         List<Event> events = eventRepository.findAllNowAvailable();
         return events.stream()
-            .map(EventMapper.INSTANCE::eventToResponse)
-            .collect(Collectors.toList());
+                .map(EventMapper.INSTANCE::eventToResponse)
+                .collect(Collectors.toList());
     }
 
     public EventDetailResponse getEventDetail(Long eventId) {

--- a/src/main/java/com/backend/connectable/event/ui/EventController.java
+++ b/src/main/java/com/backend/connectable/event/ui/EventController.java
@@ -26,6 +26,12 @@ public class EventController {
         return ResponseEntity.ok(eventResponses);
     }
 
+    @GetMapping("/today")
+    public ResponseEntity<List<EventResponse>> getNowAvailable() {
+        List<EventResponse> eventResponses = eventService.getListNowAvailable();
+        return ResponseEntity.ok(eventResponses);
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<EventDetailResponse> getEventDetail(@PathVariable("id") Long eventId) {
         EventDetailResponse eventDetailResponse = eventService.getEventDetail(eventId);

--- a/src/main/java/com/backend/connectable/event/ui/EventController.java
+++ b/src/main/java/com/backend/connectable/event/ui/EventController.java
@@ -4,14 +4,13 @@ import com.backend.connectable.event.service.EventService;
 import com.backend.connectable.event.ui.dto.EventDetailResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.backend.connectable.event.ui.dto.TicketResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,7 +44,8 @@ public class EventController {
     }
 
     @GetMapping("/{event-id}/tickets/{ticket-id}")
-    public ResponseEntity<TicketResponse> getTicketInfo(@PathVariable("event-id") Long eventId, @PathVariable("ticket-id") Long ticketId) {
+    public ResponseEntity<TicketResponse> getTicketInfo(
+            @PathVariable("event-id") Long eventId, @PathVariable("ticket-id") Long ticketId) {
         TicketResponse ticketResponse = eventService.getTicketInfo(eventId, ticketId);
         return ResponseEntity.ok(ticketResponse);
     }

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.event.domain.repository;
 
 import static com.backend.connectable.fixture.ArtistFixture.createArtistBigNaughty;
+import static com.backend.connectable.fixture.EventFixture.createEventSalesTo2023WithEventName;
 import static com.backend.connectable.fixture.EventFixture.createEventWithNameAndContractAddress;
 import static com.backend.connectable.fixture.TicketFixture.createTicketWithSalesStatus;
 import static com.backend.connectable.fixture.UserFixture.createUserJoel;
@@ -14,12 +15,10 @@ import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.backend.connectable.event.domain.dto.EventTicket;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,10 +41,14 @@ class EventRepositoryTest {
     User user = createUserJoel();
 
     String bigNaughtyEvent1ContractAddress = "0x1234";
-    Event bigNaughtyEvent1 = createEventWithNameAndContractAddress(bigNaughty, "bigNaughty1", bigNaughtyEvent1ContractAddress);
+    Event bigNaughtyEvent1 =
+            createEventWithNameAndContractAddress(
+                    bigNaughty, "bigNaughty1", bigNaughtyEvent1ContractAddress);
 
     String bigNaughtyEvent2ContractAddress = "0x5678";
-    Event bigNaughtyEvent2 = createEventWithNameAndContractAddress(bigNaughty, "bigNaughty2", bigNaughtyEvent2ContractAddress);
+    Event bigNaughtyEvent2 =
+            createEventWithNameAndContractAddress(
+                    bigNaughty, "bigNaughty2", bigNaughtyEvent2ContractAddress);
 
     @BeforeEach
     void setUp() {
@@ -73,11 +76,13 @@ class EventRepositoryTest {
                 Stream.of(bigNaughtyEvent2, bigNaughtyEvent1)
                         .allMatch(
                                 item ->
-                                    events.stream()
-                                            .map(Event::getEventName)
-                                            .anyMatch(
-                                                    eventName ->
-                                                        Objects.equals(eventName, item.getEventName())));
+                                        events.stream()
+                                                .map(Event::getEventName)
+                                                .anyMatch(
+                                                        eventName ->
+                                                                Objects.equals(
+                                                                        eventName,
+                                                                        item.getEventName())));
         assertThat(result).isTrue();
     }
 
@@ -85,12 +90,18 @@ class EventRepositoryTest {
     @Test
     void findAllTickets() {
         // given
-        Ticket ticket1SoldOut = createTicketWithSalesStatus(bigNaughtyEvent1, 1, TicketSalesStatus.SOLD_OUT);
-        Ticket ticket2SoldOut = createTicketWithSalesStatus(bigNaughtyEvent1, 2, TicketSalesStatus.SOLD_OUT);
-        Ticket ticket3Pending = createTicketWithSalesStatus(bigNaughtyEvent1, 3, TicketSalesStatus.PENDING);
-        Ticket ticket4Pending = createTicketWithSalesStatus(bigNaughtyEvent1, 4, TicketSalesStatus.PENDING);
-        Ticket ticket5OnSale = createTicketWithSalesStatus(bigNaughtyEvent1, 5, TicketSalesStatus.ON_SALE);
-        Ticket ticket6OnSale = createTicketWithSalesStatus(bigNaughtyEvent1, 6, TicketSalesStatus.ON_SALE);
+        Ticket ticket1SoldOut =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 1, TicketSalesStatus.SOLD_OUT);
+        Ticket ticket2SoldOut =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 2, TicketSalesStatus.SOLD_OUT);
+        Ticket ticket3Pending =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 3, TicketSalesStatus.PENDING);
+        Ticket ticket4Pending =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 4, TicketSalesStatus.PENDING);
+        Ticket ticket5OnSale =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 5, TicketSalesStatus.ON_SALE);
+        Ticket ticket6OnSale =
+                createTicketWithSalesStatus(bigNaughtyEvent1, 6, TicketSalesStatus.ON_SALE);
 
         ticketRepository.saveAll(
                 Arrays.asList(
@@ -127,10 +138,16 @@ class EventRepositoryTest {
     @DisplayName("현재 시각보다 판매 종료 시점이 늦은 이벤트를 조회할 수 있다")
     @Test
     void findAllNowAvailable() {
+        // given
+        Event maxEvent1 = createEventSalesTo2023WithEventName(bigNaughty, "maxEvent1");
+        Event maxEvent2 = createEventSalesTo2023WithEventName(bigNaughty, "maxEvent2");
+        eventRepository.saveAll(List.of(maxEvent1, maxEvent2));
+
         // when
         List<Event> nowAvailable = eventRepository.findAllNowAvailable();
 
         // then
+        assertThat(nowAvailable).containsExactly(maxEvent1, maxEvent2);
     }
 
     @DisplayName("아티스트 ID를 통해 아티스트의 이벤트를 조회할 수 있다.")

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -1,17 +1,20 @@
 package com.backend.connectable.event.domain.repository;
 
+import static com.backend.connectable.fixture.ArtistFixture.createArtistBigNaughty;
+import static com.backend.connectable.fixture.EventFixture.createEventWithNameAndContractAddress;
+import static com.backend.connectable.fixture.TicketFixture.createTicketWithSalesStatus;
+import static com.backend.connectable.fixture.UserFixture.createUserJoel;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
 import com.backend.connectable.event.domain.Event;
-import com.backend.connectable.event.domain.SalesOption;
 import com.backend.connectable.event.domain.Ticket;
 import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.backend.connectable.event.domain.dto.EventTicket;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
-import java.time.LocalDateTime;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -34,63 +37,15 @@ class EventRepositoryTest {
 
     @Autowired ArtistRepository artistRepository;
 
-    Artist bigNaughty =
-            Artist.builder()
-                    .bankCompany("NH")
-                    .bankAccount("9000000000099")
-                    .artistName("빅나티")
-                    .email("bignaughty@gmail.com")
-                    .password("temptemp1234")
-                    .phoneNumber("01012345678")
-                    .artistImage("ARTIST_IMAGE")
-                    .build();
+    Artist bigNaughty = createArtistBigNaughty();
 
-    User user =
-            User.builder()
-                    .phoneNumber("010-0000-0000")
-                    .klaytnAddress("0x1234")
-                    .nickname("user")
-                    .privacyAgreement(true)
-                    .isActive(true)
-                    .build();
+    User user = createUserJoel();
 
-    String joelEventContractAddress = "0x1234";
-    Event joelEvent =
-            Event.builder()
-                    .description("조엘의 콘서트 at Connectable")
-                    .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
-                    .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
-                    .contractAddress(joelEventContractAddress)
-                    .eventName("조엘의 콘서트")
-                    .eventImage("JOEL_EVENT_IMG_URL")
-                    .twitterUrl("https://github.com/joelonsw")
-                    .instagramUrl("https://www.instagram.com/jyoung_with/")
-                    .webpageUrl("https://papimon.tistory.com/")
-                    .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
-                    .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
-                    .salesOption(SalesOption.FLAT_PRICE)
-                    .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
-                    .artist(bigNaughty)
-                    .build();
+    String bigNaughtyEvent1ContractAddress = "0x1234";
+    Event bigNaughtyEvent1 = createEventWithNameAndContractAddress(bigNaughty, "bigNaughty1", bigNaughtyEvent1ContractAddress);
 
-    String ryanEventContractAddress = "0x5678";
-    Event ryanEvent =
-            Event.builder()
-                    .description("라이언 콘서트 at Connectable")
-                    .salesFrom(LocalDateTime.of(2022, 6, 11, 0, 0))
-                    .salesTo(LocalDateTime.of(2022, 6, 17, 0, 0))
-                    .contractAddress(ryanEventContractAddress)
-                    .eventName("라이언 콘서트")
-                    .eventImage("RYAN_EVENT_IMG_URL")
-                    .twitterUrl("https://twitter.com/elonmusk")
-                    .instagramUrl("https://www.instagram.com/eunbining0904/")
-                    .webpageUrl("https://nextjs.org/")
-                    .startTime(LocalDateTime.of(2022, 6, 22, 19, 30))
-                    .endTime(LocalDateTime.of(2022, 6, 22, 21, 30))
-                    .salesOption(SalesOption.FLAT_PRICE)
-                    .location("예술의 전당")
-                    .artist(bigNaughty)
-                    .build();
+    String bigNaughtyEvent2ContractAddress = "0x5678";
+    Event bigNaughtyEvent2 = createEventWithNameAndContractAddress(bigNaughty, "bigNaughty2", bigNaughtyEvent2ContractAddress);
 
     @BeforeEach
     void setUp() {
@@ -98,7 +53,7 @@ class EventRepositoryTest {
         artistRepository.deleteAll();
 
         artistRepository.save(bigNaughty);
-        eventRepository.saveAll(Arrays.asList(joelEvent, ryanEvent));
+        eventRepository.saveAll(Arrays.asList(bigNaughtyEvent1, bigNaughtyEvent2));
         userRepository.save(user);
     }
 
@@ -107,7 +62,7 @@ class EventRepositoryTest {
     void findAllContractAddresses() {
         List<String> allContractAddresses = eventRepository.findAllContractAddresses();
         assertThat(allContractAddresses)
-                .contains(joelEventContractAddress, ryanEventContractAddress);
+                .contains(bigNaughtyEvent1ContractAddress, bigNaughtyEvent2ContractAddress);
     }
 
     @DisplayName("이벤트 목록을 받아올 수 있다.")
@@ -115,7 +70,7 @@ class EventRepositoryTest {
     void findAllEventWithOrder() {
         List<Event> events = eventRepository.findAllEventWithOrder();
         boolean result =
-                Stream.of(ryanEvent, joelEvent)
+                Stream.of(bigNaughtyEvent2, bigNaughtyEvent1)
                         .allMatch(
                                 item ->
                                     events.stream()
@@ -130,59 +85,12 @@ class EventRepositoryTest {
     @Test
     void findAllTickets() {
         // given
-        Ticket ticket1SoldOut =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(1)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-                        .build();
-
-        Ticket ticket2SoldOut =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(2)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.SOLD_OUT)
-                        .build();
-
-        Ticket ticket3Pending =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(3)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.PENDING)
-                        .build();
-
-        Ticket ticket4Pending =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(4)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.PENDING)
-                        .build();
-
-        Ticket ticket5OnSale =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(5)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-                        .build();
-
-        Ticket ticket6OnSale =
-                Ticket.builder()
-                        .event(joelEvent)
-                        .tokenId(6)
-                        .tokenUri("https://token1.uri")
-                        .price(100000)
-                        .ticketSalesStatus(TicketSalesStatus.ON_SALE)
-                        .build();
+        Ticket ticket1SoldOut = createTicketWithSalesStatus(bigNaughtyEvent1, 1, TicketSalesStatus.SOLD_OUT);
+        Ticket ticket2SoldOut = createTicketWithSalesStatus(bigNaughtyEvent1, 2, TicketSalesStatus.SOLD_OUT);
+        Ticket ticket3Pending = createTicketWithSalesStatus(bigNaughtyEvent1, 3, TicketSalesStatus.PENDING);
+        Ticket ticket4Pending = createTicketWithSalesStatus(bigNaughtyEvent1, 4, TicketSalesStatus.PENDING);
+        Ticket ticket5OnSale = createTicketWithSalesStatus(bigNaughtyEvent1, 5, TicketSalesStatus.ON_SALE);
+        Ticket ticket6OnSale = createTicketWithSalesStatus(bigNaughtyEvent1, 6, TicketSalesStatus.ON_SALE);
 
         ticketRepository.saveAll(
                 Arrays.asList(
@@ -194,7 +102,7 @@ class EventRepositoryTest {
                         ticket6OnSale));
 
         // when
-        Long eventId = joelEvent.getId();
+        Long eventId = bigNaughtyEvent1.getId();
         List<EventTicket> allTickets = eventRepository.findAllTickets(eventId);
 
         // then
@@ -210,16 +118,19 @@ class EventRepositoryTest {
     @Test
     void getEventByContractAddress() {
         // given && when
-        Event event = eventRepository.findByContractAddress(joelEventContractAddress).get();
+        Event event = eventRepository.findByContractAddress(bigNaughtyEvent1ContractAddress).get();
 
         // then
-        assertThat(event).isEqualTo(joelEvent);
+        assertThat(event).isEqualTo(bigNaughtyEvent1);
     }
 
     @DisplayName("현재 시각보다 판매 종료 시점이 늦은 이벤트를 조회할 수 있다")
     @Test
     void findAllNowAvailable() {
+        // when
+        List<Event> nowAvailable = eventRepository.findAllNowAvailable();
 
+        // then
     }
 
     @DisplayName("아티스트 ID를 통해 아티스트의 이벤트를 조회할 수 있다.")
@@ -229,6 +140,6 @@ class EventRepositoryTest {
         List<Event> artistEvents = eventRepository.findAllEventsByArtistId(bigNaughty.getId());
 
         // then
-        assertThat(artistEvents).containsExactly(joelEvent, ryanEvent);
+        assertThat(artistEvents).containsExactly(bigNaughtyEvent1, bigNaughtyEvent2);
     }
 }

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -1,8 +1,8 @@
 package com.backend.connectable.event.domain.repository;
 
 import static com.backend.connectable.fixture.ArtistFixture.createArtistBigNaughty;
-import static com.backend.connectable.fixture.EventFixture.createEventSalesTo2023WithEventName;
 import static com.backend.connectable.fixture.EventFixture.createEventWithNameAndContractAddress;
+import static com.backend.connectable.fixture.EventFixture.createFutureEventWithEventName;
 import static com.backend.connectable.fixture.TicketFixture.createTicketWithSalesStatus;
 import static com.backend.connectable.fixture.UserFixture.createUserJoel;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -139,8 +139,8 @@ class EventRepositoryTest {
     @Test
     void findAllNowAvailable() {
         // given
-        Event maxEvent1 = createEventSalesTo2023WithEventName(bigNaughty, "maxEvent1");
-        Event maxEvent2 = createEventSalesTo2023WithEventName(bigNaughty, "maxEvent2");
+        Event maxEvent1 = createFutureEventWithEventName(bigNaughty, "maxEvent1");
+        Event maxEvent2 = createFutureEventWithEventName(bigNaughty, "maxEvent2");
         eventRepository.saveAll(List.of(maxEvent1, maxEvent2));
 
         // when

--- a/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/com/backend/connectable/event/domain/repository/EventRepositoryTest.java
@@ -14,6 +14,9 @@ import com.backend.connectable.user.domain.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,16 +115,14 @@ class EventRepositoryTest {
     void findAllEventWithOrder() {
         List<Event> events = eventRepository.findAllEventWithOrder();
         boolean result =
-                List.of(ryanEvent, joelEvent).stream()
+                Stream.of(ryanEvent, joelEvent)
                         .allMatch(
                                 item ->
-                                        events.stream()
-                                                .map(Event::getEventName)
-                                                .filter(
-                                                        eventName ->
-                                                                eventName == item.getEventName())
-                                                .findAny()
-                                                .isPresent());
+                                    events.stream()
+                                            .map(Event::getEventName)
+                                            .anyMatch(
+                                                    eventName ->
+                                                        Objects.equals(eventName, item.getEventName())));
         assertThat(result).isTrue();
     }
 
@@ -213,6 +214,12 @@ class EventRepositoryTest {
 
         // then
         assertThat(event).isEqualTo(joelEvent);
+    }
+
+    @DisplayName("현재 시각보다 판매 종료 시점이 늦은 이벤트를 조회할 수 있다")
+    @Test
+    void findAllNowAvailable() {
+
     }
 
     @DisplayName("아티스트 ID를 통해 아티스트의 이벤트를 조회할 수 있다.")

--- a/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
+++ b/src/test/java/com/backend/connectable/event/service/EventServiceTest.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.event.service;
 
+import static com.backend.connectable.fixture.EventFixture.createFutureEventWithEventName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,12 +87,12 @@ class EventServiceTest {
                 Event.builder()
                         .eventName("test1")
                         .eventImage("/connectable-events/image_0xtest.jpeg")
-                        .startTime(LocalDateTime.now())
                         .description("description1")
                         .contractAddress(CONTRACT_ADDRESS)
                         .contractName("event1")
                         .salesFrom(LocalDateTime.now())
                         .salesTo(LocalDateTime.now())
+                        .startTime(LocalDateTime.now())
                         .endTime(LocalDateTime.now())
                         .artist(artist1)
                         .build();
@@ -100,12 +101,12 @@ class EventServiceTest {
                 Event.builder()
                         .eventName("test2")
                         .eventImage("/connectable-events/image_0xtest.jpeg")
-                        .startTime(LocalDateTime.now())
                         .description("description2")
                         .contractAddress(CONTRACT_ADDRESS)
                         .contractName("event2")
                         .salesFrom(LocalDateTime.now())
                         .salesTo(LocalDateTime.now())
+                        .startTime(LocalDateTime.now())
                         .endTime(LocalDateTime.now())
                         .artist(artist1)
                         .build();
@@ -114,12 +115,12 @@ class EventServiceTest {
                 Event.builder()
                         .eventName("test3")
                         .eventImage("/connectable-events/image_0xtest.jpeg")
-                        .startTime(LocalDateTime.now())
                         .description("description3")
                         .contractAddress(CONTRACT_ADDRESS)
                         .contractName("event3")
                         .salesFrom(LocalDateTime.now())
                         .salesTo(LocalDateTime.now())
+                        .startTime(LocalDateTime.now())
                         .endTime(LocalDateTime.now())
                         .artist(artist1)
                         .build();
@@ -299,5 +300,24 @@ class EventServiceTest {
 
         assertThat(tickets.get(0).getTokenUri()).isEqualTo(TOKEN_URI);
         assertThat(tickets.get(0).getPrice()).isEqualTo(10000);
+    }
+
+    @DisplayName("현재 구매할 수 있는 이벤트를 조회할 수 있다.")
+    @Test
+    void getListNowAvailable() {
+        // before
+        List<EventResponse> before = eventService.getListNowAvailable();
+        assertThat(before).isEmpty();
+
+        // given
+        Event maxEvent1 = createFutureEventWithEventName(artist1, "maxEvent1");
+        Event maxEvent2 = createFutureEventWithEventName(artist1, "maxEvent2");
+        eventRepository.saveAll(List.of(maxEvent1, maxEvent2));
+
+        // when
+        List<EventResponse> after = eventService.getListNowAvailable();
+
+        // then
+        assertThat(after).hasSize(2);
     }
 }

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -60,10 +60,10 @@ class EventControllerTest {
                     EVENT_ID_2,
                     "test2",
                     "/connectable-events/image_0xtest.jpeg",
-                    LocalDateTime.now(),
+                    LocalDateTime.now().plusYears(1L),
                     "description2",
-                    LocalDateTime.now(),
-                    LocalDateTime.now());
+                    LocalDateTime.now().plusYears(1L),
+                    LocalDateTime.now().plusYears(1L));
 
     private static final EventDetailResponse EVENT_DETAIL_RESPONSE =
             new EventDetailResponse(
@@ -157,6 +157,23 @@ class EventControllerTest {
                 .andExpect(jsonPath("$[1].name").value("test2"))
                 .andExpect(jsonPath("$[1].description").value("description2"))
                 .andDo(print());
+    }
+
+    @DisplayName("오늘 기점으로 종료가 안된 이벤트를 여러개 조회한다.")
+    @WithMockUser
+    @Test
+    void getEventsListNowAvailable() throws Exception {
+        // given
+        List<EventResponse> mockedEventNowAvailable = List.of(EVENT_RESPONSE_2);
+        given(eventService.getListNowAvailable()).willReturn(mockedEventNowAvailable);
+
+        // expected
+        mockMvc.perform(get("/events/today").contentType(APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").exists())
+            .andExpect(jsonPath("$[0].name").value("test2"))
+            .andExpect(jsonPath("$[0].description").value("description2"))
+            .andDo(print());
     }
 
     @DisplayName("이벤트 번호를 사용하여 특정 이벤트를 조회한다.")

--- a/src/test/java/com/backend/connectable/fixture/EventFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/EventFixture.java
@@ -48,6 +48,25 @@ public class EventFixture {
                 .build();
     }
 
+    public static Event createEventWithNameAndContractAddress(Artist artist, String eventName, String contractAddress) {
+        return Event.builder()
+            .description("콘서트 at Connectable")
+            .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+            .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+            .contractAddress(contractAddress)
+            .eventName(eventName)
+            .eventImage("EVENT_IMG_URL")
+            .twitterUrl("https://github.com/joelonsw")
+            .instagramUrl("https://www.instagram.com/jyoung_with/")
+            .webpageUrl("https://papimon.tistory.com/")
+            .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+            .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+            .salesOption(SalesOption.FLAT_PRICE)
+            .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
+            .artist(artist)
+            .build();
+    }
+
     public static Event createEventValidContractAddressMockedKas(Artist artist) {
         return Event.builder()
                 .description("콘서트 at Connectable")

--- a/src/test/java/com/backend/connectable/fixture/EventFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/EventFixture.java
@@ -48,23 +48,43 @@ public class EventFixture {
                 .build();
     }
 
-    public static Event createEventWithNameAndContractAddress(Artist artist, String eventName, String contractAddress) {
+    public static Event createEventSalesTo2023WithEventName(Artist artist, String eventName) {
         return Event.builder()
-            .description("콘서트 at Connectable")
-            .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
-            .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
-            .contractAddress(contractAddress)
-            .eventName(eventName)
-            .eventImage("EVENT_IMG_URL")
-            .twitterUrl("https://github.com/joelonsw")
-            .instagramUrl("https://www.instagram.com/jyoung_with/")
-            .webpageUrl("https://papimon.tistory.com/")
-            .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
-            .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
-            .salesOption(SalesOption.FLAT_PRICE)
-            .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
-            .artist(artist)
-            .build();
+                .description("콘서트 at Connectable")
+                .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+                .salesTo(LocalDateTime.of(2023, 12, 30, 0, 0))
+                .contractAddress("0x5555aaaa")
+                .eventName(eventName)
+                .eventImage("EVENT_IMG_URL")
+                .twitterUrl("https://github.com/joelonsw")
+                .instagramUrl("https://www.instagram.com/jyoung_with/")
+                .webpageUrl("https://papimon.tistory.com/")
+                .startTime(LocalDateTime.of(2023, 12, 31, 18, 0))
+                .endTime(LocalDateTime.of(2023, 12, 31, 19, 0))
+                .salesOption(SalesOption.FLAT_PRICE)
+                .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
+                .artist(artist)
+                .build();
+    }
+
+    public static Event createEventWithNameAndContractAddress(
+            Artist artist, String eventName, String contractAddress) {
+        return Event.builder()
+                .description("콘서트 at Connectable")
+                .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
+                .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
+                .contractAddress(contractAddress)
+                .eventName(eventName)
+                .eventImage("EVENT_IMG_URL")
+                .twitterUrl("https://github.com/joelonsw")
+                .instagramUrl("https://www.instagram.com/jyoung_with/")
+                .webpageUrl("https://papimon.tistory.com/")
+                .startTime(LocalDateTime.of(2022, 8, 1, 18, 0))
+                .endTime(LocalDateTime.of(2022, 8, 1, 19, 0))
+                .salesOption(SalesOption.FLAT_PRICE)
+                .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
+                .artist(artist)
+                .build();
     }
 
     public static Event createEventValidContractAddressMockedKas(Artist artist) {

--- a/src/test/java/com/backend/connectable/fixture/EventFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/EventFixture.java
@@ -48,19 +48,19 @@ public class EventFixture {
                 .build();
     }
 
-    public static Event createEventSalesTo2023WithEventName(Artist artist, String eventName) {
+    public static Event createFutureEventWithEventName(Artist artist, String eventName) {
         return Event.builder()
                 .description("콘서트 at Connectable")
-                .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
-                .salesTo(LocalDateTime.of(2023, 12, 30, 0, 0))
+                .salesFrom(LocalDateTime.now().plusYears(1L))
+                .salesTo(LocalDateTime.now().plusYears(2L))
                 .contractAddress("0x5555aaaa")
                 .eventName(eventName)
                 .eventImage("EVENT_IMG_URL")
                 .twitterUrl("https://github.com/joelonsw")
                 .instagramUrl("https://www.instagram.com/jyoung_with/")
                 .webpageUrl("https://papimon.tistory.com/")
-                .startTime(LocalDateTime.of(2023, 12, 31, 18, 0))
-                .endTime(LocalDateTime.of(2023, 12, 31, 19, 0))
+                .startTime(LocalDateTime.now().plusYears(2L))
+                .endTime(LocalDateTime.now().plusYears(2L))
                 .salesOption(SalesOption.FLAT_PRICE)
                 .location("서울특별시 강남구 테헤란로 311 아남타워빌딩 7층")
                 .artist(artist)

--- a/src/test/java/com/backend/connectable/fixture/TicketFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/TicketFixture.java
@@ -27,15 +27,16 @@ public class TicketFixture {
                 .build();
     }
 
-    public static Ticket createTicketWithSalesStatus(Event event, int tokenId, TicketSalesStatus ticketSalesStatus) {
+    public static Ticket createTicketWithSalesStatus(
+            Event event, int tokenId, TicketSalesStatus ticketSalesStatus) {
         return Ticket.builder()
-            .event(event)
-            .tokenUri(String.format(TOKEN_URI_FORMAT, tokenId))
-            .tokenId(tokenId)
-            .price(TICKET_PRICE)
-            .ticketSalesStatus(ticketSalesStatus)
-            .ticketMetadata(generateTicketMetadata(event, tokenId))
-            .build();
+                .event(event)
+                .tokenUri(String.format(TOKEN_URI_FORMAT, tokenId))
+                .tokenId(tokenId)
+                .price(TICKET_PRICE)
+                .ticketSalesStatus(ticketSalesStatus)
+                .ticketMetadata(generateTicketMetadata(event, tokenId))
+                .build();
     }
 
     private static TicketMetadata generateTicketMetadata(Event event, int tokenId) {

--- a/src/test/java/com/backend/connectable/fixture/TicketFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/TicketFixture.java
@@ -27,6 +27,17 @@ public class TicketFixture {
                 .build();
     }
 
+    public static Ticket createTicketWithSalesStatus(Event event, int tokenId, TicketSalesStatus ticketSalesStatus) {
+        return Ticket.builder()
+            .event(event)
+            .tokenUri(String.format(TOKEN_URI_FORMAT, tokenId))
+            .tokenId(tokenId)
+            .price(TICKET_PRICE)
+            .ticketSalesStatus(ticketSalesStatus)
+            .ticketMetadata(generateTicketMetadata(event, tokenId))
+            .build();
+    }
+
     private static TicketMetadata generateTicketMetadata(Event event, int tokenId) {
         return TicketMetadata.builder()
                 .name(event.getEventName())


### PR DESCRIPTION
## 작업 내용
1. **오늘 구매 가능한 이벤트를 조회하는 API를 구현합니다**
    - GET /events/today 엔드포인트를 통해 오늘 구매 가능한 이벤트를 조회합니다
    - 이벤트의 salesTo 필드보다 현재 시각이 더 작다면 조회의 대상이 됩니다. 
    - 레포지토리/서비스/컨트롤러 테스트 추가하여 작성하였습니다. 

## 주의 사항

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
