### PR TITLE
feat: 댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/backend/connectable/artist/domain/Comment.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Comment.java
@@ -1,5 +1,7 @@
 package com.backend.connectable.artist.domain;
 
+import com.backend.connectable.exception.ConnectableException;
+import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.global.entity.BaseEntity;
 import com.backend.connectable.user.domain.User;
 import java.util.Objects;
@@ -7,6 +9,7 @@ import javax.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Getter
@@ -27,12 +30,21 @@ public class Comment extends BaseEntity {
 
     @Lob private String contents;
 
+    private boolean isDeleted = Boolean.FALSE;
+
     @Builder
-    public Comment(Long id, Artist artist, User user, String contents) {
+    public Comment(Long id, Artist artist, User user, String contents, boolean isDeleted) {
         this.id = id;
         this.artist = artist;
         this.user = user;
         this.contents = contents;
+        this.isDeleted = isDeleted;
+    }
+
+    public void isCommentAuthor(User user) {
+        if (!this.user.equals(user)) {
+            throw new ConnectableException(HttpStatus.UNAUTHORIZED, ErrorType.NOT_A_COMMENT_AUTHOR);
+        }
     }
 
     @Override

--- a/src/main/java/com/backend/connectable/artist/domain/Comment.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Comment.java
@@ -1,7 +1,5 @@
 package com.backend.connectable.artist.domain;
 
-import com.backend.connectable.exception.ConnectableException;
-import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.global.entity.BaseEntity;
 import com.backend.connectable.user.domain.User;
 import java.util.Objects;
@@ -9,7 +7,6 @@ import javax.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Entity
 @Getter
@@ -41,10 +38,8 @@ public class Comment extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
-    public void isCommentAuthor(User user) {
-        if (!this.user.equals(user)) {
-            throw new ConnectableException(HttpStatus.UNAUTHORIZED, ErrorType.NOT_A_COMMENT_AUTHOR);
-        }
+    public boolean isCommentAuthor(User user) {
+        return this.user.equals(user);
     }
 
     @Override

--- a/src/main/java/com/backend/connectable/artist/domain/dto/ArtistComment.java
+++ b/src/main/java/com/backend/connectable/artist/domain/dto/ArtistComment.java
@@ -15,12 +15,19 @@ public class ArtistComment {
     private String nickname;
     private LocalDateTime createdDate;
     private String contents;
+    private boolean isDeleted;
 
     @QueryProjection
-    public ArtistComment(Long id, String nickname, LocalDateTime createdDate, String contents) {
+    public ArtistComment(
+            Long id,
+            String nickname,
+            LocalDateTime createdDate,
+            String contents,
+            boolean isDeleted) {
         this.id = id;
         this.nickname = nickname;
         this.createdDate = createdDate;
         this.contents = contents;
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface CommentRepositoryCustom {
 
     List<ArtistComment> getCommentsByArtistId(Long artistId);
+
+    void deleteComment(Long artistId, Long commentId);
 }

--- a/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
@@ -27,7 +27,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                         comment.id,
                                         user.nickname,
                                         comment.createdDate,
-                                        comment.contents))
+                                        comment.contents,
+                                        comment.isDeleted))
                         .from(comment)
                         .innerJoin(user)
                         .on(user.id.eq(comment.user.id))

--- a/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
@@ -8,7 +8,9 @@ import com.backend.connectable.artist.domain.dto.QArtistComment;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import javax.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
@@ -17,7 +19,6 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    @Override
     public List<ArtistComment> getCommentsByArtistId(Long artistId) {
         List<ArtistComment> result =
                 queryFactory
@@ -34,5 +35,13 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         .fetch();
 
         return result;
+    }
+
+    public void deleteComment(Long artistId, Long commentId) {
+        queryFactory
+                .update(comment)
+                .set(comment.isDeleted, true)
+                .where(comment.id.eq(commentId).and(comment.artist.id.eq(artistId)))
+                .execute();
     }
 }

--- a/src/main/java/com/backend/connectable/artist/mapper/ArtistMapper.java
+++ b/src/main/java/com/backend/connectable/artist/mapper/ArtistMapper.java
@@ -1,0 +1,16 @@
+package com.backend.connectable.artist.mapper;
+
+import com.backend.connectable.artist.domain.dto.ArtistComment;
+import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ArtistMapper {
+
+    ArtistMapper INSTANCE = Mappers.getMapper(ArtistMapper.class);
+
+    @Mapping(target = "writtenAt", source = "createdDate")
+    ArtistCommentResponse artistCommentToResponse(ArtistComment artistComment);
+}

--- a/src/main/java/com/backend/connectable/artist/service/ArtistService.java
+++ b/src/main/java/com/backend/connectable/artist/service/ArtistService.java
@@ -68,6 +68,18 @@ public class ArtistService {
         commentRepository.save(comment);
     }
 
+    public List<ArtistCommentResponse> getArtistComments(Long artistId) {
+        List<ArtistComment> artistComments = commentRepository.getCommentsByArtistId(artistId);
+        return ArtistCommentResponse.toList(artistComments);
+    }
+
+    @Transactional
+    public void deleteComment(ConnectableUserDetails userDetails, Long artistId, Long commentId) {
+        Comment comment = getComment(commentId);
+        comment.isCommentAuthor(getUser(userDetails));
+        commentRepository.deleteComment(artistId, comment.getId());
+    }
+
     private User getUser(ConnectableUserDetails userDetails) {
         return userRepository
                 .findByKlaytnAddress(userDetails.getKlaytnAddress())
@@ -86,8 +98,12 @@ public class ArtistService {
                                         HttpStatus.BAD_REQUEST, ErrorType.ARTIST_NOT_EXISTS));
     }
 
-    public List<ArtistCommentResponse> getArtistComments(Long artistId) {
-        List<ArtistComment> artistComments = commentRepository.getCommentsByArtistId(artistId);
-        return ArtistCommentResponse.toList(artistComments);
+    private Comment getComment(Long commentId) {
+        return commentRepository
+                .findById(commentId)
+                .orElseThrow(
+                        () ->
+                                new ConnectableException(
+                                        HttpStatus.BAD_REQUEST, ErrorType.COMMENT_NOT_EXIST));
     }
 }

--- a/src/main/java/com/backend/connectable/artist/ui/ArtistController.java
+++ b/src/main/java/com/backend/connectable/artist/ui/ArtistController.java
@@ -56,4 +56,13 @@ public class ArtistController {
         artistService.createComment(userDetails, artistId, artistCommentRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @DeleteMapping("/{artist-id}/comments")
+    public ResponseEntity<Void> deleteArtistComment(
+            @AuthenticationPrincipal ConnectableUserDetails userDetails,
+            @PathVariable("artist-id") Long artistId,
+            @RequestParam(name = "commentId") Long commentId) {
+        artistService.deleteComment(userDetails, artistId, commentId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/backend/connectable/artist/ui/ArtistController.java
+++ b/src/main/java/com/backend/connectable/artist/ui/ArtistController.java
@@ -44,7 +44,7 @@ public class ArtistController {
     public ResponseEntity<List<ArtistCommentResponse>> getArtistComments(
             @PathVariable("artist-id") Long artistId) {
         List<ArtistCommentResponse> artistCommentResponses =
-                artistService.getArtistComments(artistId);
+                artistService.getUndeletedArtistComments(artistId);
         return ResponseEntity.ok(artistCommentResponses);
     }
 

--- a/src/main/java/com/backend/connectable/exception/ErrorType.java
+++ b/src/main/java/com/backend/connectable/exception/ErrorType.java
@@ -54,7 +54,9 @@ public enum ErrorType {
     THREAD_INTERRUPTED("ADMIN-005", "쓰레드에 문제가 발생했습니다."),
 
     ARTIST_NOT_EXISTS("ARTIST-001", "존재하지 않는 아티스트입니다."),
-    ;
+
+    COMMENT_NOT_EXIST("COMMENT-001", "존재하지 않는 댓글입니다."),
+    NOT_A_COMMENT_AUTHOR("COMMENT-002", "댓글 작성자가 아닙니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/backend/connectable/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/backend/connectable/security/config/SecurityConfiguration.java
@@ -36,6 +36,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticated()
                 .antMatchers(POST, "/artists/{artist-id}/comments")
                 .authenticated()
+                .antMatchers(PUT, "/artists/{artist-id}/comments")
+                .authenticated()
                 .anyRequest()
                 .permitAll()
                 .and()

--- a/src/main/java/com/backend/connectable/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/backend/connectable/security/config/SecurityConfiguration.java
@@ -36,7 +36,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticated()
                 .antMatchers(POST, "/artists/{artist-id}/comments")
                 .authenticated()
-                .antMatchers(PUT, "/artists/{artist-id}/comments")
+                .antMatchers(DELETE, "/artists/{artist-id}/comments")
                 .authenticated()
                 .anyRequest()
                 .permitAll()

--- a/src/main/resources/db/migration/V12__add_comment_is_deleted_column.sql
+++ b/src/main/resources/db/migration/V12__add_comment_is_deleted_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comment ADD COLUMN is_deleted bit(1) DEFAULT false NOT NULL;

--- a/src/test/java/com/backend/connectable/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/backend/connectable/artist/service/ArtistServiceTest.java
@@ -123,23 +123,31 @@ class ArtistServiceTest {
 
     @DisplayName("특정 아티스트 페이지에 작성된 코멘트 목록을 조회할 수 있다.")
     @Test
-    void getArtistComments() {
+    void getUndeletedArtistComments() {
         // given
         Comment comment1 =
-                Comment.builder().user(user).artist(artist2).contents("contents1 입니당").build();
+                Comment.builder()
+                        .user(user)
+                        .artist(artist2)
+                        .contents("contents1 입니당")
+                        .isDeleted(true)
+                        .build();
         Comment comment2 =
-                Comment.builder().user(user).artist(artist2).contents("contents2 입니당").build();
+                Comment.builder()
+                        .user(user)
+                        .artist(artist2)
+                        .contents("contents2 입니당")
+                        .isDeleted(false)
+                        .build();
         commentRepository.saveAll(List.of(comment1, comment2));
 
         // when
         List<ArtistCommentResponse> artistComments =
-                artistService.getArtistComments(artist2.getId());
+                artistService.getUndeletedArtistComments(artist2.getId());
 
         // then
-        assertThat(artistComments.get(0).getContents()).isEqualTo(comment1.getContents());
-        assertThat(artistComments.get(0).getWrittenAt()).isEqualTo(comment1.getCreatedDate());
-        assertThat(artistComments.get(1).getContents()).isEqualTo(comment2.getContents());
-        assertThat(artistComments.get(1).getWrittenAt()).isEqualTo(comment2.getCreatedDate());
+        assertThat(artistComments.get(0).getContents()).isEqualTo(comment2.getContents());
+        assertThat(artistComments.get(0).getWrittenAt()).isEqualTo(comment2.getCreatedDate());
     }
 
     @DisplayName("찾을 수 없는 유저일 경우에는 코멘트 등록에 실패한다.")

--- a/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
+++ b/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
@@ -115,7 +115,7 @@ class ArtistControllerTest {
     @Test
     void getArtistComments() throws Exception {
         // given & when
-        given(artistService.getArtistComments(ARTIST_RESPONSE_1.getArtistId()))
+        given(artistService.getUndeletedArtistComments(ARTIST_RESPONSE_1.getArtistId()))
                 .willReturn(List.of(ARTIST_COMMENT_RESPONSE_1, ARTIST_COMMENT_RESPONSE_2));
 
         // then

--- a/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
+++ b/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
@@ -1,11 +1,11 @@
 package com.backend.connectable.artist.ui;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,6 +149,21 @@ class ArtistControllerTest {
                                 .contentType(APPLICATION_JSON)
                                 .content(artistCommentAsJson))
                 .andExpect(status().isCreated())
+                .andDo(print());
+    }
+
+    @DisplayName("작성한 코멘트를 삭제한다.")
+    @WithUserDetails("0x1111")
+    @Test
+    void deleteArtistComment() throws Exception {
+        // given & when
+        doNothing().when(artistService).deleteComment(any(), anyLong(), anyLong());
+
+        // then
+        mockMvc.perform(
+                        delete("/artists/{artist-id}/comments?commentId={comment-id}", 1L, 1L)
+                                .contentType(APPLICATION_JSON))
+                .andExpect(status().isNoContent())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## 작업 내용
- 아티스크 댓글 삭제 기능 추가
  - Querydsl을 이용하여 Soft delete 처리
    - @SQLDelete ( [link](https://www.jpa-buddy.com/blog/soft-deletion-in-hibernate-things-you-may-miss/)  ) 와 더티 체킹을 고려하다, 기존 user 엔티티 소프트 삭제 방법과 동일하게 QueryDsl 로 업데이트 치는 방향으로 처리하였습니다.  
    - 관련하여 comment 테이블에 is_deleted 컬럼 추가가 진행됩니다.
  - 작성자 판단 여부는 도메인에 질의하는 것이 적합하다 판단하여 isCommentAuthor 도메인에 질의합니다. 
  void type으로 작성한 것이 꺼림직 한데, boolean 타입으로 변경 후 외부에서 Exception을 터트리는 것이 좋을지 피드백 부탁드립니다.. 🤗

## 주의 사항
- Artist가 삭제되는 등의 이유로 artistId 에 매핑되는 튜플이 존재하지 않을 경우 프론트에서 코멘트에서 댓글이 노출되지 않을 것이라 판단하여 로직 내 아티스트 검증 로직은 포함하지 않았습니다. 관련하여 생각치 못한 이슈 케이스가 존재할지 궁금합니다.. 찜찜하네요.
  - artistId가 필요할까 고민하다 artist > comment 계층 구조를 가지고 있는걸 생각하면 URL Path에서 artistId도 같이 확인해야 하는게 맞는것 같기도 하고 아리송하네요.. 우선은 제가 생각할 때의 RestFul은 동일한 리소스에 대해 행동이 다르다면 URI는 같고 메소드는 달라야한다 라고 생각하여 DeleteMapping으로 동일 엔드포인트와 매핑해주었습니다.
- 기존 노션 내 API 명세를 수정하여 작성자가 아닌 경우의 HttpStatus Code는 (As-Is : 400, To-Be : [401](https://developer.mozilla.org/ko/docs/Web/HTTP/Status/401) ) 401로 수정하여 적용했습니다.

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
