### PR TITLE
feat: 아티스트 상세 조회시 공지사항 및 추가정보 필드 추가

### DIFF
--- a/src/main/java/com/backend/connectable/artist/domain/Artist.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Artist.java
@@ -1,14 +1,13 @@
 package com.backend.connectable.artist.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -33,8 +32,28 @@ public class Artist {
 
     private String artistImage;
 
+    private String twitterUrl;
+
+    private String instagramUrl;
+
+    private String webpageUrl;
+
+    private String description;
+
     @Builder
-    public Artist(Long id, String bankCompany, String bankAccount, String artistName, String email, String password, String phoneNumber, String artistImage) {
+    public Artist(
+            Long id,
+            String bankCompany,
+            String bankAccount,
+            String artistName,
+            String email,
+            String password,
+            String phoneNumber,
+            String artistImage,
+            String description,
+            String twitterUrl,
+            String instagramUrl,
+            String webpageUrl) {
         this.id = id;
         this.bankCompany = bankCompany;
         this.bankAccount = bankAccount;
@@ -43,6 +62,10 @@ public class Artist {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.artistImage = artistImage;
+        this.description = description;
+        this.twitterUrl = twitterUrl;
+        this.instagramUrl = instagramUrl;
+        this.webpageUrl = webpageUrl;
     }
 
     @Override

--- a/src/main/java/com/backend/connectable/artist/domain/Notice.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Notice.java
@@ -19,6 +19,7 @@ public class Notice extends BaseEntity {
     @JoinColumn(nullable = false)
     private Artist artist;
 
+    @Enumerated(EnumType.STRING)
     private NoticeStatus noticeStatus;
 
     private String title;

--- a/src/main/java/com/backend/connectable/artist/domain/Notice.java
+++ b/src/main/java/com/backend/connectable/artist/domain/Notice.java
@@ -1,0 +1,37 @@
+package com.backend.connectable.artist.domain;
+
+import com.backend.connectable.global.entity.BaseEntity;
+import javax.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private Artist artist;
+
+    private NoticeStatus noticeStatus;
+
+    private String title;
+
+    @Lob private String contents;
+
+    @Builder
+    public Notice(
+            Long id, Artist artist, NoticeStatus noticeStatus, String title, String contents) {
+        this.id = id;
+        this.artist = artist;
+        this.noticeStatus = noticeStatus;
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/backend/connectable/artist/domain/NoticeStatus.java
+++ b/src/main/java/com/backend/connectable/artist/domain/NoticeStatus.java
@@ -1,0 +1,6 @@
+package com.backend.connectable.artist.domain;
+
+public enum NoticeStatus {
+    EXPOSURE,
+    NON_EXPOSURE
+}

--- a/src/main/java/com/backend/connectable/artist/domain/NoticeStatus.java
+++ b/src/main/java/com/backend/connectable/artist/domain/NoticeStatus.java
@@ -1,6 +1,15 @@
 package com.backend.connectable.artist.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum NoticeStatus {
-    EXPOSURE,
-    NON_EXPOSURE
+    EXPOSURE("exposure"),
+    NON_EXPOSURE("non_exposure");
+
+    private final String status;
+
+    NoticeStatus(String status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/backend/connectable/artist/domain/dto/ArtistDetail.java
+++ b/src/main/java/com/backend/connectable/artist/domain/dto/ArtistDetail.java
@@ -23,7 +23,6 @@ public class ArtistDetail {
     public ArtistDetail(
             String image,
             String name,
-            String artistDescription,
             String twitterUrl,
             String instagramUrl,
             String webpageUrl,

--- a/src/main/java/com/backend/connectable/artist/domain/dto/ArtistDetail.java
+++ b/src/main/java/com/backend/connectable/artist/domain/dto/ArtistDetail.java
@@ -1,0 +1,40 @@
+package com.backend.connectable.artist.domain.dto;
+
+import com.backend.connectable.artist.domain.Notice;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ArtistDetail {
+
+    private String image;
+    private String name;
+    private String twitterUrl;
+    private String instagramUrl;
+    private String webpageUrl;
+    private String description;
+    private Notice notice;
+
+    @QueryProjection
+    public ArtistDetail(
+            String image,
+            String name,
+            String artistDescription,
+            String twitterUrl,
+            String instagramUrl,
+            String webpageUrl,
+            String description,
+            Notice notice) {
+        this.image = image;
+        this.name = name;
+        this.twitterUrl = twitterUrl;
+        this.instagramUrl = instagramUrl;
+        this.webpageUrl = webpageUrl;
+        this.description = description;
+        this.notice = notice;
+    }
+}

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepository.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepository.java
@@ -3,5 +3,4 @@ package com.backend.connectable.artist.domain.repository;
 import com.backend.connectable.artist.domain.Artist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArtistRepository extends JpaRepository<Artist, Long> {
-}
+public interface ArtistRepository extends JpaRepository<Artist, Long>, ArtistRepositoryCustom {}

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.backend.connectable.artist.domain.repository;
+
+import com.backend.connectable.artist.domain.dto.ArtistDetail;
+import java.util.Optional;
+
+public interface ArtistRepositoryCustom {
+
+    Optional<ArtistDetail> findArtistDetailByArtistId(Long artistId);
+}

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.backend.connectable.artist.domain.repository;
+
+import static com.backend.connectable.artist.domain.QArtist.artist;
+import static com.backend.connectable.artist.domain.QNotice.notice;
+
+import com.backend.connectable.artist.domain.NoticeStatus;
+import com.backend.connectable.artist.domain.dto.ArtistDetail;
+import com.backend.connectable.artist.domain.dto.QArtistDetail;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ArtistRepositoryImpl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ArtistRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public Optional<ArtistDetail> findArtistDetailByArtistId(Long artistId) {
+        ArtistDetail result =
+                queryFactory
+                        .select(
+                                new QArtistDetail(
+                                        artist.artistImage.as("image"),
+                                        artist.artistName.as("name"),
+                                        artist.description.as("artistDescription"),
+                                        artist.twitterUrl,
+                                        artist.instagramUrl,
+                                        artist.webpageUrl,
+                                        artist.description,
+                                        notice))
+                        .from(artist)
+                        .leftJoin(notice)
+                        .on(
+                                notice.artist
+                                        .id
+                                        .eq(artist.id)
+                                        .and(notice.noticeStatus.eq(NoticeStatus.EXPOSURE)))
+                        .where(artist.id.eq(artistId))
+                        .orderBy(notice.createdDate.desc())
+                        .limit(1)
+                        .fetchOne();
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
@@ -30,7 +30,7 @@ public class ArtistRepositoryImpl {
                                         artist.twitterUrl,
                                         artist.instagramUrl,
                                         artist.webpageUrl,
-                                        artist.description.as("artisxtDescription"),
+                                        artist.description,
                                         notice))
                         .from(artist)
                         .leftJoin(notice)

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
@@ -27,11 +27,10 @@ public class ArtistRepositoryImpl {
                                 new QArtistDetail(
                                         artist.artistImage.as("image"),
                                         artist.artistName.as("name"),
-                                        artist.description.as("artistDescription"),
                                         artist.twitterUrl,
                                         artist.instagramUrl,
                                         artist.webpageUrl,
-                                        artist.description,
+                                        artist.description.as("artisxtDescription"),
                                         notice))
                         .from(artist)
                         .leftJoin(notice)

--- a/src/main/java/com/backend/connectable/artist/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/NoticeRepository.java
@@ -1,0 +1,6 @@
+package com.backend.connectable.artist.domain.repository;
+
+import com.backend.connectable.artist.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {}

--- a/src/main/java/com/backend/connectable/artist/mapper/ArtistMapper.java
+++ b/src/main/java/com/backend/connectable/artist/mapper/ArtistMapper.java
@@ -1,7 +1,9 @@
 package com.backend.connectable.artist.mapper;
 
 import com.backend.connectable.artist.domain.dto.ArtistComment;
+import com.backend.connectable.artist.domain.dto.ArtistDetail;
 import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
+import com.backend.connectable.artist.ui.dto.ArtistDetailResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -13,4 +15,6 @@ public interface ArtistMapper {
 
     @Mapping(target = "writtenAt", source = "createdDate")
     ArtistCommentResponse artistCommentToResponse(ArtistComment artistComment);
+
+    ArtistDetailResponse artistDetailToResponse(ArtistDetail artistDetail);
 }

--- a/src/main/java/com/backend/connectable/artist/service/ArtistService.java
+++ b/src/main/java/com/backend/connectable/artist/service/ArtistService.java
@@ -3,6 +3,7 @@ package com.backend.connectable.artist.service;
 import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.Comment;
 import com.backend.connectable.artist.domain.dto.ArtistComment;
+import com.backend.connectable.artist.domain.dto.ArtistDetail;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
 import com.backend.connectable.artist.domain.repository.CommentRepository;
 import com.backend.connectable.artist.mapper.ArtistMapper;
@@ -41,8 +42,15 @@ public class ArtistService {
     }
 
     public ArtistDetailResponse getArtistDetail(Long artistId) {
-        Artist artist = getArtist(artistId);
-        return ArtistDetailResponse.from(artist);
+        ArtistDetail artistDetail =
+                artistRepository
+                        .findArtistDetailByArtistId(artistId)
+                        .orElseThrow(
+                                () ->
+                                        new ConnectableException(
+                                                HttpStatus.BAD_REQUEST,
+                                                ErrorType.ARTIST_NOT_EXISTS));
+        return ArtistMapper.INSTANCE.artistDetailToResponse(artistDetail);
     }
 
     public List<EventResponse> getArtistEvent(Long artistId) {

--- a/src/main/java/com/backend/connectable/artist/ui/dto/ArtistDetailResponse.java
+++ b/src/main/java/com/backend/connectable/artist/ui/dto/ArtistDetailResponse.java
@@ -1,7 +1,6 @@
 package com.backend.connectable.artist.ui.dto;
 
 import com.backend.connectable.artist.domain.Artist;
-import com.backend.connectable.artist.domain.Notice;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -20,7 +19,7 @@ public class ArtistDetailResponse {
     private String instagramUrl;
     private String webpageUrl;
     private String description;
-    private Notice notice;
+    private NoticeResponse notice;
 
     public ArtistDetailResponse(Long id, String name, String image) {
         this.id = id;
@@ -36,7 +35,7 @@ public class ArtistDetailResponse {
             String instagramUrl,
             String webpageUrl,
             String description,
-            Notice notice) {
+            NoticeResponse notice) {
         this.id = id;
         this.name = name;
         this.image = image;

--- a/src/main/java/com/backend/connectable/artist/ui/dto/ArtistDetailResponse.java
+++ b/src/main/java/com/backend/connectable/artist/ui/dto/ArtistDetailResponse.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.artist.ui.dto;
 
 import com.backend.connectable.artist.domain.Artist;
+import com.backend.connectable.artist.domain.Notice;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -12,14 +13,38 @@ import lombok.Setter;
 @Setter
 public class ArtistDetailResponse {
 
-    private Long artistId;
-    private String artistName;
-    private String artistImage;
+    private Long id;
+    private String name;
+    private String image;
+    private String twitterUrl;
+    private String instagramUrl;
+    private String webpageUrl;
+    private String description;
+    private Notice notice;
 
-    public ArtistDetailResponse(Long artistId, String artistName, String artistImage) {
-        this.artistId = artistId;
-        this.artistName = artistName;
-        this.artistImage = artistImage;
+    public ArtistDetailResponse(Long id, String name, String image) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+    }
+
+    public ArtistDetailResponse(
+            Long id,
+            String name,
+            String image,
+            String twitterUrl,
+            String instagramUrl,
+            String webpageUrl,
+            String description,
+            Notice notice) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+        this.twitterUrl = twitterUrl;
+        this.instagramUrl = instagramUrl;
+        this.webpageUrl = webpageUrl;
+        this.description = description;
+        this.notice = notice;
     }
 
     public static ArtistDetailResponse from(Artist artist) {

--- a/src/main/java/com/backend/connectable/artist/ui/dto/NoticeResponse.java
+++ b/src/main/java/com/backend/connectable/artist/ui/dto/NoticeResponse.java
@@ -1,0 +1,22 @@
+package com.backend.connectable.artist.ui.dto;
+
+import com.backend.connectable.artist.domain.NoticeStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeResponse {
+
+    private String title;
+    private String contents;
+    private NoticeStatus noticeStatus;
+
+    public NoticeResponse(String title, String contents, NoticeStatus noticeStatus) {
+        this.title = title;
+        this.contents = contents;
+        this.noticeStatus = noticeStatus;
+    }
+}

--- a/src/main/java/com/backend/connectable/artist/ui/dto/NoticeResponse.java
+++ b/src/main/java/com/backend/connectable/artist/ui/dto/NoticeResponse.java
@@ -12,11 +12,11 @@ public class NoticeResponse {
 
     private String title;
     private String contents;
-    private NoticeStatus noticeStatus;
+    private String noticeStatus;
 
     public NoticeResponse(String title, String contents, NoticeStatus noticeStatus) {
         this.title = title;
         this.contents = contents;
-        this.noticeStatus = noticeStatus;
+        this.noticeStatus = noticeStatus.getStatus();
     }
 }

--- a/src/main/resources/db/migration/V13__add_notice_table_and_artist_columns.sql
+++ b/src/main/resources/db/migration/V13__add_notice_table_and_artist_columns.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `notice` (
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `created_date` datetime(6) NOT NULL,
+    `modified_date` datetime(6) NOT NULL,
+    `status` varchar(255) DEFAULT NULL,
+    `title` varchar(255) NOT NULL,
+    `contents` longtext NOT NULL,
+    `artist_id` bigint NOT NULL,
+    PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+;
+
+ALTER TABLE notice ADD CONSTRAINT `fk_notice_artist` FOREIGN KEY (`artist_id`) REFERENCES `artist` (`id`);
+
+ALTER TABLE artist ADD COLUMN description varchar(255) DEFAULT NULL;
+ALTER TABLE artist ADD COLUMN twitter_url varchar(255) DEFAULT NULL;
+ALTER TABLE artist ADD COLUMN webpage_url varchar(255) DEFAULT NULL;
+ALTER TABLE artist ADD COLUMN instagram_url varchar(255) DEFAULT NULL;

--- a/src/main/resources/db/migration/V13__add_notice_table_and_artist_columns.sql
+++ b/src/main/resources/db/migration/V13__add_notice_table_and_artist_columns.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS `notice` (
     `id` bigint NOT NULL AUTO_INCREMENT,
     `created_date` datetime(6) NOT NULL,
     `modified_date` datetime(6) NOT NULL,
-    `status` varchar(255) DEFAULT NULL,
+    `notice_status` varchar(255) DEFAULT NULL,
     `title` varchar(255) NOT NULL,
     `contents` longtext NOT NULL,
     `artist_id` bigint NOT NULL,

--- a/src/test/java/com/backend/connectable/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/backend/connectable/artist/service/ArtistServiceTest.java
@@ -8,8 +8,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.backend.connectable.artist.domain.Artist;
 import com.backend.connectable.artist.domain.Comment;
+import com.backend.connectable.artist.domain.Notice;
+import com.backend.connectable.artist.domain.NoticeStatus;
 import com.backend.connectable.artist.domain.repository.ArtistRepository;
 import com.backend.connectable.artist.domain.repository.CommentRepository;
+import com.backend.connectable.artist.domain.repository.NoticeRepository;
 import com.backend.connectable.artist.ui.dto.ArtistCommentRequest;
 import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
 import com.backend.connectable.artist.ui.dto.ArtistDetailResponse;
@@ -38,6 +41,7 @@ class ArtistServiceTest {
     @Autowired ArtistRepository artistRepository;
     @Autowired UserRepository userRepository;
     @Autowired CommentRepository commentRepository;
+    @Autowired NoticeRepository noticeRepository;
 
     @Autowired EventRepository eventRepository;
 
@@ -57,6 +61,7 @@ class ArtistServiceTest {
 
     @BeforeEach
     void setUp() {
+        noticeRepository.deleteAll();
         eventRepository.deleteAll();
         commentRepository.deleteAll();
         artistRepository.deleteAll();
@@ -84,23 +89,32 @@ class ArtistServiceTest {
 
         // then
         assertThat(artistDetailResponses.size()).isEqualTo(2L);
-        assertThat(artistDetailResponses.get(0).getArtistImage())
-                .isEqualTo(artist1.getArtistImage());
-        assertThat(artistDetailResponses.get(0).getArtistName()).isEqualTo(artist1.getArtistName());
-        assertThat(artistDetailResponses.get(1).getArtistImage())
-                .isEqualTo(artist2.getArtistImage());
-        assertThat(artistDetailResponses.get(1).getArtistName()).isEqualTo(artist2.getArtistName());
+        assertThat(artistDetailResponses.get(0).getImage()).isEqualTo(artist1.getArtistImage());
+        assertThat(artistDetailResponses.get(0).getName()).isEqualTo(artist1.getArtistName());
+        assertThat(artistDetailResponses.get(1).getImage()).isEqualTo(artist2.getArtistImage());
+        assertThat(artistDetailResponses.get(1).getName()).isEqualTo(artist2.getArtistName());
     }
 
     @DisplayName("특정 아티스트의 상세 정보 조회에 성공한다.")
     @Test
     void getArtistDetail() {
         // given & when
+        Notice notice =
+                Notice.builder()
+                        .artist(artist1)
+                        .noticeStatus(NoticeStatus.EXPOSURE)
+                        .title("공지사항1")
+                        .contents("공지사항 1의 내용")
+                        .build();
+        noticeRepository.save(notice);
         ArtistDetailResponse artistDetailResponse = artistService.getArtistDetail(artist1.getId());
 
         // then
-        assertThat(artistDetailResponse.getArtistName()).isEqualTo(artist1.getArtistName());
-        assertThat(artistDetailResponse.getArtistImage()).isEqualTo(artist1.getArtistImage());
+        assertThat(artistDetailResponse.getName()).isEqualTo(artist1.getArtistName());
+        assertThat(artistDetailResponse.getImage()).isEqualTo(artist1.getArtistImage());
+        assertThat(artistDetailResponse.getDescription()).isEqualTo(artist1.getDescription());
+        assertThat(artistDetailResponse.getNotice().getTitle()).isEqualTo(notice.getTitle());
+        assertThat(artistDetailResponse.getNotice().getContents()).isEqualTo(notice.getContents());
     }
 
     @DisplayName("아티스트 페이지에서 방문록을 작성할 수 있다.")

--- a/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
+++ b/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
@@ -10,12 +10,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.backend.connectable.artist.domain.Notice;
 import com.backend.connectable.artist.domain.NoticeStatus;
 import com.backend.connectable.artist.service.ArtistService;
 import com.backend.connectable.artist.ui.dto.ArtistCommentRequest;
 import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
 import com.backend.connectable.artist.ui.dto.ArtistDetailResponse;
+import com.backend.connectable.artist.ui.dto.NoticeResponse;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -37,10 +37,10 @@ class ArtistControllerTest {
     @Autowired private ObjectMapper objectMapper;
     @MockBean private ArtistService artistService;
 
-    private static final Notice NOTICE_1 =
-            new Notice(1L, null, NoticeStatus.EXPOSURE, "타이틀1", "내용1");
-    private static final Notice NOTICE_2 =
-            new Notice(2L, null, NoticeStatus.NON_EXPOSURE, "타이틀2", "내용2");
+    private static final NoticeResponse NOTICE_1 =
+            new NoticeResponse("타이틀1", "내용1", NoticeStatus.EXPOSURE);
+    private static final NoticeResponse NOTICE_2 =
+            new NoticeResponse("타이틀2", "내용2", NoticeStatus.EXPOSURE);
     private static final ArtistDetailResponse ARTIST_RESPONSE_1 =
             new ArtistDetailResponse(
                     1L, "artist1", "https://artist1.img", null, null, null, "아티스트1 설명", NOTICE_1);

--- a/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
+++ b/src/test/java/com/backend/connectable/event/ui/EventControllerTest.java
@@ -169,11 +169,11 @@ class EventControllerTest {
 
         // expected
         mockMvc.perform(get("/events/today").contentType(APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0]").exists())
-            .andExpect(jsonPath("$[0].name").value("test2"))
-            .andExpect(jsonPath("$[0].description").value("description2"))
-            .andDo(print());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists())
+                .andExpect(jsonPath("$[0].name").value("test2"))
+                .andExpect(jsonPath("$[0].description").value("description2"))
+                .andDo(print());
     }
 
     @DisplayName("이벤트 번호를 사용하여 특정 이벤트를 조회한다.")

--- a/src/test/java/com/backend/connectable/fixture/ArtistFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/ArtistFixture.java
@@ -15,6 +15,9 @@ public class ArtistFixture {
                 .password("temptemp1234")
                 .phoneNumber("01085161399")
                 .artistImage("ARTIST_IMAGE")
+                .instagramUrl("https://www.instagram.com/bignaughtyboi/")
+                .webpageUrl("https://www.instagram.com/bignaughtyboi/")
+                .description("목소리가 늑대같은 그남자")
                 .build();
     }
 
@@ -27,6 +30,9 @@ public class ArtistFixture {
                 .password("temptemp1234")
                 .phoneNumber("01033339999")
                 .artistImage("https://image2.url")
+                .instagramUrl("https://www.instagram.com/_choiyuree/")
+                .webpageUrl("https://www.instagram.com/_choiyuree/")
+                .description("목소리가 옥구슬 같은 그녀")
                 .build();
     }
 }


### PR DESCRIPTION
## 작업 내용
- ArtistDetail 조회시 하기 필드가 추가되었습니다.
  - twitterUrl, instagramUrl, webpageUrl, description, notice
- Notice 테이블이 추가되었습니다. 
  - 추후 공지사항 노출/비노출을 고려하여 Enum 타입으로 공지사항 타입을 관리합니다.

## 주의 사항
- DDL 스크립트에 대한 상세한 검토 부탁드립니다. 🙏 
- artist 도메인에 대해 필드명에 artist가 포함되지 않는 것으로 조건이 변경되어 DTO 및 테스트 코드 내 필드명 변경하였습니다.

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
