### PR TITLE
feat: WebClient timeout 설정

### DIFF
--- a/src/main/java/com/backend/connectable/exception/ErrorType.java
+++ b/src/main/java/com/backend/connectable/exception/ErrorType.java
@@ -58,7 +58,9 @@ public enum ErrorType {
     ARTIST_NOT_EXISTS("ARTIST-001", "존재하지 않는 아티스트입니다."),
 
     COMMENT_NOT_EXIST("COMMENT-001", "존재하지 않는 댓글입니다."),
-    NOT_A_COMMENT_AUTHOR("COMMENT-002", "댓글 작성자가 아닙니다.");
+    NOT_A_COMMENT_AUTHOR("COMMENT-002", "댓글 작성자가 아닙니다."),
+
+    UNEXPECTED_SERVER_ERROR("SERVER-001", "서버 관리자에게 문의하세요.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/connectable/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.backend.connectable.exception;
 
-import java.util.Arrays;
+import static com.backend.connectable.exception.ErrorType.UNEXPECTED_SERVER_ERROR;
+
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -21,9 +23,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<KasExceptionResponse> handleKasException(KasException e) {
         KasExceptionResponse kasExceptionResponse = e.getKasExceptionResponse();
         log.error("KAS ERROR URL : " + kasExceptionResponse.getUrl());
-        log.error(
-                "KAS ERROR EXPECTED RETURN TYPE : "
-                        + kasExceptionResponse.getExpectedResponseType());
+        log.error("KAS ERROR EXCEPTION MESSAGE : " + kasExceptionResponse.getExceptionMessage());
         return ResponseEntity.internalServerError().body(kasExceptionResponse);
     }
 
@@ -39,9 +39,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(Exception e) {
-        String errorMessage = e.getMessage();
-        Arrays.stream(e.getStackTrace()).map(StackTraceElement::toString).forEach(log::error);
-        return ResponseEntity.internalServerError().body(errorMessage);
+    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
+        String unexpectedErrorTrace = ExceptionUtils.getStackTrace(e);
+        log.error(unexpectedErrorTrace);
+        return ResponseEntity.internalServerError()
+                .body(
+                        new ExceptionResponse(
+                                UNEXPECTED_SERVER_ERROR.getErrorCode(),
+                                UNEXPECTED_SERVER_ERROR.getMessage()));
     }
 }

--- a/src/main/java/com/backend/connectable/exception/KasException.java
+++ b/src/main/java/com/backend/connectable/exception/KasException.java
@@ -7,7 +7,7 @@ public class KasException extends RuntimeException {
 
     private final KasExceptionResponse kasExceptionResponse;
 
-    public KasException(String url, String expectedResponseType) {
-        this.kasExceptionResponse = new KasExceptionResponse(url, expectedResponseType);
+    public KasException(String url, String exceptionMessage) {
+        this.kasExceptionResponse = new KasExceptionResponse(url, exceptionMessage);
     }
 }

--- a/src/main/java/com/backend/connectable/exception/KasExceptionResponse.java
+++ b/src/main/java/com/backend/connectable/exception/KasExceptionResponse.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class KasExceptionResponse {
     private String url;
-    private String expectedResponseType;
+    private String exceptionMessage;
 }

--- a/src/main/java/com/backend/connectable/kas/config/KasWebClient.java
+++ b/src/main/java/com/backend/connectable/kas/config/KasWebClient.java
@@ -1,6 +1,8 @@
 package com.backend.connectable.kas.config;
 
 import com.backend.connectable.exception.KasException;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -12,6 +14,9 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KasWebClient {
 
+    private static final String TIMEOUT_EXCEPTION_MESSAGE = "WebClient Timeout";
+    private static final String UNEXPECTED_RESPONSE_MESSAGE = "Expected response of ";
+
     private final WebClient kasWebClient;
 
     public <T> Mono<T> getForObject(String url, Class<T> responseType) {
@@ -22,9 +27,17 @@ public class KasWebClient {
                 .onStatus(
                         HttpStatus::isError,
                         response -> {
-                            throw new KasException(url, responseType.getName());
+                            throw new KasException(
+                                    url,
+                                    UNEXPECTED_RESPONSE_MESSAGE + responseType.getSimpleName());
                         })
-                .bodyToMono(responseType);
+                .bodyToMono(responseType)
+                .timeout(Duration.ofSeconds(5))
+                .onErrorMap(
+                        TimeoutException.class,
+                        exception -> {
+                            throw new KasException(url, TIMEOUT_EXCEPTION_MESSAGE);
+                        });
     }
 
     public <T> Mono<T> postForObject(String url, Object requestBody, Class<T> responseType) {
@@ -36,9 +49,17 @@ public class KasWebClient {
                 .onStatus(
                         HttpStatus::isError,
                         response -> {
-                            throw new KasException(url, responseType.getName());
+                            throw new KasException(
+                                    url,
+                                    UNEXPECTED_RESPONSE_MESSAGE + responseType.getSimpleName());
                         })
-                .bodyToMono(responseType);
+                .bodyToMono(responseType)
+                .timeout(Duration.ofSeconds(5))
+                .onErrorMap(
+                        TimeoutException.class,
+                        exception -> {
+                            throw new KasException(url, TIMEOUT_EXCEPTION_MESSAGE);
+                        });
     }
 
     public <T> Mono<T> deleteForObject(String url, Object requestBody, Class<T> responseType) {
@@ -50,8 +71,16 @@ public class KasWebClient {
                 .onStatus(
                         HttpStatus::isError,
                         response -> {
-                            throw new KasException(url, responseType.getName());
+                            throw new KasException(
+                                    url,
+                                    UNEXPECTED_RESPONSE_MESSAGE + responseType.getSimpleName());
                         })
-                .bodyToMono(responseType);
+                .bodyToMono(responseType)
+                .timeout(Duration.ofSeconds(5))
+                .onErrorMap(
+                        TimeoutException.class,
+                        exception -> {
+                            throw new KasException(url, TIMEOUT_EXCEPTION_MESSAGE);
+                        });
     }
 }


### PR DESCRIPTION
## 작업 내용
1. **WebClient Timeout을 설정합니다**
    - 문득 외부 KAS API가 장애가 발생해서 죽으면 어쩌지? 에 대한 고민을 해봤습니다.
    - 물론 좋은건 블록체인 노드를 직접 운영하는 java 코드로 백업 플랜을 짜두는 것 같은데, 현 시점으론 불가능해보이고, 
    - 최소한 API 조회가 안되면 Timeout error log라도 띄워서 우리가 인식할 수 있어야한다는 생각해 해당 기능을 추가합니다.
    - 5초 안에 Reactive Stream 내에서 응답이 없다면 예외가 발생합니다!

2. **GlobalExceptionHandler의 예상치못한 Exception 핸들러를 수정합니다**
    - 가끔 슬랙에 미친듯이 알람이 뜰때가 있는데요. 
    - 스택트레이스를 String으로 한줄씩 .forEach() 에러레벨로 출력시키고 있더군요. 에러레벨의 로그가 찍히면 우리 슬랙으로 알림이 가니 그랬던 것 같습니다. 
    - 스택트레이스 한줄로 압축해서 로그 남기도록 수정했습니다 :) 

## 주의 사항
- 외부 시스템 장애에 대해 대처하는 방법을 고민해볼 수 있는 글이 있어 공유합니당 (https://techblog.woowahan.com/6447/)
    - 우리 Connectable 같은 경우, Kas 외부 모듈을 쓰는 기능들에서 장애의 영향을 받을 기능들은
        - 컨트랙트 배포 및 토큰 민팅 -> 이건 정상화 후 수행해도 됨
        - 사용자 토큰 구매시 전송해주기 -> 구매 내역은 RDB에 남으니, 정상화 된 후 보내준다고 공지해주기로 우선은 해결할 수 있어보임
        - 내 티켓 조회하기 -> 대책이 필요해보임. 오프라인 모드를 통한 프론트엔드 캐싱? 일정 주기로 스냅샷을 찍어 본인의 티켓을 조회할 때 스냅샷으로 대체하는 등의 방법이 생각남
        - 토큰 홀더인지 조회하기 -> 블록체인 트랜잭션을 볼 수 있는 API가 있다면 이중화를 할 수 있지 않을까 싶음 (klaytnfinder 같은걸로...?)
    - 외부 시스템 장애 발생 시 어떻게 처리하는게 좋을지 같이 얘기해봐도 재미있을 것 같습니다 :)

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
