### PR TITLE
feat: 아티스트 댓글 조회 시 티켓 정보 반환

### DIFF
--- a/src/main/java/com/backend/connectable/artist/domain/dto/ArtistComment.java
+++ b/src/main/java/com/backend/connectable/artist/domain/dto/ArtistComment.java
@@ -1,5 +1,6 @@
 package com.backend.connectable.artist.domain.dto;
 
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -13,21 +14,30 @@ public class ArtistComment {
 
     private Long id;
     private String nickname;
+    private String klaytnAddress;
     private LocalDateTime createdDate;
     private String contents;
     private boolean isDeleted;
+
+    private TicketMetadata ticketMetadata;
 
     @QueryProjection
     public ArtistComment(
             Long id,
             String nickname,
+            String klaytnAddress,
             LocalDateTime createdDate,
             String contents,
             boolean isDeleted) {
         this.id = id;
         this.nickname = nickname;
+        this.klaytnAddress = klaytnAddress;
         this.createdDate = createdDate;
         this.contents = contents;
         this.isDeleted = isDeleted;
+    }
+
+    public void addHoldingTicketMetadata(TicketMetadata ticketMetadata) {
+        this.ticketMetadata = ticketMetadata;
     }
 }

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.backend.connectable.artist.domain.repository;
 
 import com.backend.connectable.artist.domain.dto.ArtistDetail;
+import java.util.List;
 import java.util.Optional;
 
 public interface ArtistRepositoryCustom {
 
     Optional<ArtistDetail> findArtistDetailByArtistId(Long artistId);
+
+    List<String> findArtistEventsContractAddresses(Long artistId);
 }

--- a/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/ArtistRepositoryImpl.java
@@ -2,17 +2,19 @@ package com.backend.connectable.artist.domain.repository;
 
 import static com.backend.connectable.artist.domain.QArtist.artist;
 import static com.backend.connectable.artist.domain.QNotice.notice;
+import static com.backend.connectable.event.domain.QEvent.event;
 
 import com.backend.connectable.artist.domain.NoticeStatus;
 import com.backend.connectable.artist.domain.dto.ArtistDetail;
 import com.backend.connectable.artist.domain.dto.QArtistDetail;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class ArtistRepositoryImpl {
+public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
@@ -45,5 +47,16 @@ public class ArtistRepositoryImpl {
                         .limit(1)
                         .fetchOne();
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<String> findArtistEventsContractAddresses(Long artistId) {
+        return queryFactory
+                .select(event.contractAddress)
+                .from(event)
+                .innerJoin(artist)
+                .on(event.artist.id.eq(artist.id))
+                .where(event.artist.id.eq(artistId))
+                .fetch();
     }
 }

--- a/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/artist/domain/repository/CommentRepositoryImpl.java
@@ -20,22 +20,20 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     }
 
     public List<ArtistComment> getCommentsByArtistId(Long artistId) {
-        List<ArtistComment> result =
-                queryFactory
-                        .select(
-                                new QArtistComment(
-                                        comment.id,
-                                        user.nickname,
-                                        comment.createdDate,
-                                        comment.contents,
-                                        comment.isDeleted))
-                        .from(comment)
-                        .innerJoin(user)
-                        .on(user.id.eq(comment.user.id))
-                        .where(comment.artist.id.eq(artistId))
-                        .fetch();
-
-        return result;
+        return queryFactory
+                .select(
+                        new QArtistComment(
+                                comment.id,
+                                user.nickname,
+                                user.klaytnAddress,
+                                comment.createdDate,
+                                comment.contents,
+                                comment.isDeleted))
+                .from(comment)
+                .innerJoin(user)
+                .on(user.id.eq(comment.user.id))
+                .where(comment.artist.id.eq(artistId))
+                .fetch();
     }
 
     public void deleteComment(Long artistId, Long commentId) {

--- a/src/main/java/com/backend/connectable/artist/service/ArtistService.java
+++ b/src/main/java/com/backend/connectable/artist/service/ArtistService.java
@@ -12,15 +12,20 @@ import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
 import com.backend.connectable.artist.ui.dto.ArtistDetailResponse;
 import com.backend.connectable.artist.ui.dto.ArtistNftHolderResponse;
 import com.backend.connectable.event.domain.Event;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.domain.repository.EventRepository;
+import com.backend.connectable.event.domain.repository.TicketRepository;
 import com.backend.connectable.event.mapper.EventMapper;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
 import com.backend.connectable.kas.service.KasService;
+import com.backend.connectable.kas.service.token.dto.TokenIdentifier;
+import com.backend.connectable.kas.service.token.dto.TokenIdentifierByKlaytnAddress;
 import com.backend.connectable.security.custom.ConnectableUserDetails;
 import com.backend.connectable.user.domain.User;
 import com.backend.connectable.user.domain.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +43,7 @@ public class ArtistService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final EventRepository eventRepository;
+    private final TicketRepository ticketRepository;
 
     public List<ArtistDetailResponse> getAllArtists() {
         List<Artist> artists = artistRepository.findAll();
@@ -82,13 +88,56 @@ public class ArtistService {
     }
 
     public List<ArtistCommentResponse> getUndeletedArtistComments(Long artistId) {
-        List<ArtistComment> artistComments =
+        List<ArtistComment> undeletedArtistComments =
                 commentRepository.getCommentsByArtistId(artistId).stream()
                         .filter(comment -> !comment.isDeleted())
                         .collect(Collectors.toList());
-        return artistComments.stream()
+
+        List<ArtistComment> holderArtistComments =
+                findHolderComments(undeletedArtistComments, artistId);
+        return holderArtistComments.stream()
                 .map(ArtistMapper.INSTANCE::artistCommentToResponse)
                 .collect(Collectors.toList());
+    }
+
+    private List<ArtistComment> findHolderComments(
+            List<ArtistComment> undeletedArtistComments, Long artistId) {
+        List<String> artistEventsContactAddresses =
+                artistRepository.findArtistEventsContractAddresses(artistId);
+        List<String> commentAuthorKlaytnAddresses =
+                undeletedArtistComments.stream()
+                        .map(ArtistComment::getKlaytnAddress)
+                        .distinct()
+                        .collect(Collectors.toList());
+
+        TokenIdentifierByKlaytnAddress artistTokenHolders =
+                kasService.findTokenHoldingStatus(
+                        artistEventsContactAddresses, commentAuthorKlaytnAddresses);
+        return parseHolderComments(undeletedArtistComments, artistTokenHolders);
+    }
+
+    private List<ArtistComment> parseHolderComments(
+            List<ArtistComment> undeletedArtistComments,
+            TokenIdentifierByKlaytnAddress artistTokenHolders) {
+        List<ArtistComment> holderArtistComments = new ArrayList<>();
+
+        for (ArtistComment artistComment : undeletedArtistComments) {
+            String authorKlaytnAddress = artistComment.getKlaytnAddress();
+            if (artistTokenHolders.isHolder(authorKlaytnAddress)) {
+                TokenIdentifier tokenIdentifier =
+                        artistTokenHolders.getTokenIdentifier(authorKlaytnAddress);
+                artistComment.addHoldingTicketMetadata(findTicketMetadata(tokenIdentifier));
+                holderArtistComments.add(artistComment);
+            }
+        }
+
+        return holderArtistComments;
+    }
+
+    private TicketMetadata findTicketMetadata(TokenIdentifier tokenIdentifier) {
+        int tokenId = tokenIdentifier.getTokenId();
+        String tokenUri = tokenIdentifier.getTokenUri();
+        return ticketRepository.findMetadataByTokenIdAndTokenUri(tokenId, tokenUri);
     }
 
     @Transactional

--- a/src/main/java/com/backend/connectable/artist/service/ArtistService.java
+++ b/src/main/java/com/backend/connectable/artist/service/ArtistService.java
@@ -19,6 +19,7 @@ import com.backend.connectable.event.mapper.EventMapper;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.backend.connectable.exception.ConnectableException;
 import com.backend.connectable.exception.ErrorType;
+import com.backend.connectable.global.aop.TimeCheck;
 import com.backend.connectable.kas.service.KasService;
 import com.backend.connectable.kas.service.token.dto.TokenIdentifier;
 import com.backend.connectable.kas.service.token.dto.TokenIdentifierByKlaytnAddress;
@@ -87,6 +88,7 @@ public class ArtistService {
         commentRepository.save(comment);
     }
 
+    @TimeCheck
     public List<ArtistCommentResponse> getUndeletedArtistComments(Long artistId) {
         List<ArtistComment> undeletedArtistComments =
                 commentRepository.getCommentsByArtistId(artistId).stream()

--- a/src/main/java/com/backend/connectable/artist/ui/dto/ArtistCommentResponse.java
+++ b/src/main/java/com/backend/connectable/artist/ui/dto/ArtistCommentResponse.java
@@ -1,5 +1,7 @@
 package com.backend.connectable.artist.ui.dto;
 
+import com.backend.connectable.event.domain.TicketMetadata;
+import com.backend.connectable.event.ui.dto.TicketMetadataResponse;
 import com.backend.connectable.global.util.DateTimeUtil;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -15,11 +17,17 @@ public class ArtistCommentResponse {
     private String nickname;
     private String contents;
     private Long writtenAt;
+    private TicketMetadataResponse ticketMetadata;
 
     @Builder
-    public ArtistCommentResponse(String nickname, String contents, LocalDateTime writtenAt) {
+    public ArtistCommentResponse(
+            String nickname,
+            String contents,
+            LocalDateTime writtenAt,
+            TicketMetadata ticketMetadata) {
         this.nickname = nickname;
         this.contents = contents;
         this.writtenAt = DateTimeUtil.toEpochMilliSeconds(writtenAt);
+        this.ticketMetadata = TicketMetadataResponse.of(ticketMetadata);
     }
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryCustom.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.backend.connectable.event.domain.repository;
 
 import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
 
 public interface TicketRepositoryCustom {
 
     long modifyTicketSalesStatusExpire();
 
     Ticket findOneOnSaleOfEvent(Long eventId);
+
+    TicketMetadata findMetadataByTokenIdAndTokenUri(int tokenId, String tokenUri);
 }

--- a/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryImpl.java
+++ b/src/main/java/com/backend/connectable/event/domain/repository/TicketRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.backend.connectable.event.domain.QEvent.event;
 import static com.backend.connectable.event.domain.QTicket.ticket;
 
 import com.backend.connectable.event.domain.Ticket;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.domain.TicketSalesStatus;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,18 +22,15 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom {
     }
 
     public long modifyTicketSalesStatusExpire() {
-        long fetchedRowCount =
-                queryFactory
-                        .update(ticket)
-                        .set(ticket.ticketSalesStatus, TicketSalesStatus.EXPIRED)
-                        .where(
-                                ticket.event.id.in(
-                                        JPAExpressions.select(event.id)
-                                                .from(event)
-                                                .where(event.salesTo.before(LocalDateTime.now()))))
-                        .execute();
-
-        return fetchedRowCount;
+        return queryFactory
+                .update(ticket)
+                .set(ticket.ticketSalesStatus, TicketSalesStatus.EXPIRED)
+                .where(
+                        ticket.event.id.in(
+                                JPAExpressions.select(event.id)
+                                        .from(event)
+                                        .where(event.salesTo.before(LocalDateTime.now()))))
+                .execute();
     }
 
     @Override
@@ -46,6 +44,15 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom {
                                 .eq(eventId)
                                 .and(ticket.ticketSalesStatus.eq(TicketSalesStatus.ON_SALE)))
                 .limit(1)
+                .fetchOne();
+    }
+
+    @Override
+    public TicketMetadata findMetadataByTokenIdAndTokenUri(int tokenId, String tokenUri) {
+        return queryFactory
+                .select(ticket.ticketMetadata)
+                .from(ticket)
+                .where(ticket.tokenId.eq(tokenId).and(ticket.tokenUri.eq(tokenUri)))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/backend/connectable/kas/service/KasService.java
+++ b/src/main/java/com/backend/connectable/kas/service/KasService.java
@@ -7,10 +7,7 @@ import com.backend.connectable.kas.service.contract.dto.ContractDeployResponse;
 import com.backend.connectable.kas.service.contract.dto.ContractItemResponse;
 import com.backend.connectable.kas.service.contract.dto.ContractItemsResponse;
 import com.backend.connectable.kas.service.token.KasTokenService;
-import com.backend.connectable.kas.service.token.dto.TokenHistoriesResponse;
-import com.backend.connectable.kas.service.token.dto.TokenIdentifier;
-import com.backend.connectable.kas.service.token.dto.TokenResponse;
-import com.backend.connectable.kas.service.token.dto.TokensResponse;
+import com.backend.connectable.kas.service.token.dto.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -115,5 +112,11 @@ public class KasService {
                 .values()
                 .stream()
                 .anyMatch(TokensResponse::hasItem);
+    }
+
+    @TimeCheck
+    public TokenIdentifierByKlaytnAddress findTokenHoldingStatus(
+            List<String> contractAddresses, List<String> klaytnAddresses) {
+        return kasTokenService.findTokenHoldingStatus(contractAddresses, klaytnAddresses);
     }
 }

--- a/src/main/java/com/backend/connectable/kas/service/token/dto/TokenIdentifierByKlaytnAddress.java
+++ b/src/main/java/com/backend/connectable/kas/service/token/dto/TokenIdentifierByKlaytnAddress.java
@@ -1,0 +1,37 @@
+package com.backend.connectable.kas.service.token.dto;
+
+import static com.backend.connectable.exception.ErrorType.UNEXPECTED_SERVER_ERROR;
+
+import com.backend.connectable.exception.ConnectableException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public class TokenIdentifierByKlaytnAddress {
+
+    private Map<String, TokenIdentifier> tokenHolderStatus;
+
+    public static TokenIdentifierByKlaytnAddress of(Map<String, TokensResponse> holderStatus) {
+        Map<String, TokenIdentifier> tokenHolderStatus =
+                holderStatus.entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        entry -> entry.getValue().getFirstTokenIdentifier()));
+        return new TokenIdentifierByKlaytnAddress(tokenHolderStatus);
+    }
+
+    public boolean isHolder(String klaytnAddress) {
+        return tokenHolderStatus.containsKey(klaytnAddress);
+    }
+
+    public TokenIdentifier getTokenIdentifier(String klaytnAddress) {
+        if (!isHolder(klaytnAddress)) {
+            throw new ConnectableException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, UNEXPECTED_SERVER_ERROR);
+        }
+        return tokenHolderStatus.get(klaytnAddress);
+    }
+}

--- a/src/main/java/com/backend/connectable/kas/service/token/dto/TokensResponse.java
+++ b/src/main/java/com/backend/connectable/kas/service/token/dto/TokensResponse.java
@@ -1,11 +1,15 @@
 package com.backend.connectable.kas.service.token.dto;
 
+import static com.backend.connectable.exception.ErrorType.UNEXPECTED_SERVER_ERROR;
+
+import com.backend.connectable.exception.ConnectableException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
@@ -23,6 +27,15 @@ public class TokensResponse {
         return items.stream()
                 .map(TokenResponse::generateTokenIdentifier)
                 .collect(Collectors.toList());
+    }
+
+    public TokenIdentifier getFirstTokenIdentifier() {
+        if (!hasItem()) {
+            throw new ConnectableException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, UNEXPECTED_SERVER_ERROR);
+        }
+        TokenResponse tokenResponse = items.get(0);
+        return tokenResponse.generateTokenIdentifier();
     }
 
     public boolean hasItem() {

--- a/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
+++ b/src/test/java/com/backend/connectable/artist/ui/ArtistControllerTest.java
@@ -17,9 +17,11 @@ import com.backend.connectable.artist.ui.dto.ArtistCommentResponse;
 import com.backend.connectable.artist.ui.dto.ArtistDetailResponse;
 import com.backend.connectable.artist.ui.dto.ArtistNftHolderResponse;
 import com.backend.connectable.artist.ui.dto.NoticeResponse;
+import com.backend.connectable.event.domain.TicketMetadata;
 import com.backend.connectable.event.ui.dto.EventResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,10 +61,28 @@ class ArtistControllerTest {
                     LocalDateTime.now(),
                     LocalDateTime.now());
 
+    private static final TicketMetadata SAMPLE_TICKET_METADATA =
+            TicketMetadata.builder()
+                    .name("메타데이터")
+                    .description("메타데이터 at Connectable")
+                    .image(
+                            "https://connectable-events.s3.ap-northeast-2.amazonaws.com/ticket_test2.png")
+                    .attributes(
+                            new HashMap<>() {
+                                {
+                                    put("Background", "Yellow");
+                                    put("Artist", "Joel");
+                                    put("Seat", "A5");
+                                }
+                            })
+                    .build();
+
     private static final ArtistCommentResponse ARTIST_COMMENT_RESPONSE_1 =
-            new ArtistCommentResponse("nickname1", "contents1", LocalDateTime.now());
+            new ArtistCommentResponse(
+                    "nickname1", "contents1", LocalDateTime.now(), SAMPLE_TICKET_METADATA);
     private static final ArtistCommentResponse ARTIST_COMMENT_RESPONSE_2 =
-            new ArtistCommentResponse("nickname2", "contents2", LocalDateTime.now());
+            new ArtistCommentResponse(
+                    "nickname2", "contents2", LocalDateTime.now(), SAMPLE_TICKET_METADATA);
 
     @DisplayName("모든 아티스트 조회에 성공한다.")
     @Test
@@ -141,8 +161,20 @@ class ArtistControllerTest {
                 .andExpect(jsonPath("$[1]").exists())
                 .andExpect(jsonPath("$[0].nickname").value(ARTIST_COMMENT_RESPONSE_1.getNickname()))
                 .andExpect(jsonPath("$[0].contents").value(ARTIST_COMMENT_RESPONSE_1.getContents()))
+                .andExpect(
+                        jsonPath("$[0].ticketMetadata.name")
+                                .value(SAMPLE_TICKET_METADATA.getName()))
+                .andExpect(
+                        jsonPath("$[0].ticketMetadata.description")
+                                .value(SAMPLE_TICKET_METADATA.getDescription()))
                 .andExpect(jsonPath("$[1].nickname").value(ARTIST_COMMENT_RESPONSE_2.getNickname()))
                 .andExpect(jsonPath("$[1].contents").value(ARTIST_COMMENT_RESPONSE_2.getContents()))
+                .andExpect(
+                        jsonPath("$[1].ticketMetadata.name")
+                                .value(SAMPLE_TICKET_METADATA.getName()))
+                .andExpect(
+                        jsonPath("$[1].ticketMetadata.description")
+                                .value(SAMPLE_TICKET_METADATA.getDescription()))
                 .andDo(print());
     }
 

--- a/src/test/java/com/backend/connectable/fixture/EventFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/EventFixture.java
@@ -5,6 +5,7 @@ import com.backend.connectable.event.domain.Event;
 import com.backend.connectable.event.domain.SalesOption;
 import com.backend.connectable.kas.service.mockserver.KasMockRequest;
 import java.time.LocalDateTime;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class EventFixture {
 
@@ -30,11 +31,12 @@ public class EventFixture {
     }
 
     public static Event createEventWithName(Artist artist, String eventName) {
+        String randomContractAddress = RandomStringUtils.randomAlphabetic(8).toLowerCase();
         return Event.builder()
                 .description("콘서트 at Connectable")
                 .salesFrom(LocalDateTime.of(2022, 7, 12, 0, 0))
                 .salesTo(LocalDateTime.of(2022, 7, 30, 0, 0))
-                .contractAddress("0x5555aaaa")
+                .contractAddress(randomContractAddress)
                 .eventName(eventName)
                 .eventImage("EVENT_IMG_URL")
                 .twitterUrl("https://github.com/joelonsw")

--- a/src/test/java/com/backend/connectable/fixture/TicketFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/TicketFixture.java
@@ -27,6 +27,17 @@ public class TicketFixture {
                 .build();
     }
 
+    public static Ticket createTicket(Event event, int tokenId, String tokenUri) {
+        return Ticket.builder()
+                .event(event)
+                .tokenUri(tokenUri)
+                .tokenId(tokenId)
+                .price(TICKET_PRICE)
+                .ticketSalesStatus(TicketSalesStatus.ON_SALE)
+                .ticketMetadata(generateTicketMetadata(event, tokenId))
+                .build();
+    }
+
     public static Ticket createTicketWithSalesStatus(
             Event event, int tokenId, TicketSalesStatus ticketSalesStatus) {
         return Ticket.builder()

--- a/src/test/java/com/backend/connectable/fixture/UserFixture.java
+++ b/src/test/java/com/backend/connectable/fixture/UserFixture.java
@@ -1,6 +1,7 @@
 package com.backend.connectable.fixture;
 
 import static com.backend.connectable.kas.service.mockserver.KasMockRequest.VALID_OWNER_ADDRESS;
+import static com.backend.connectable.kas.service.mockserver.KasMockRequest.VALID_OWNER_ADDRESS2;
 
 import com.backend.connectable.user.domain.User;
 
@@ -20,7 +21,7 @@ public class UserFixture {
 
     public static User createUserJoel() {
         return User.builder()
-                .klaytnAddress(VALID_OWNER_ADDRESS)
+                .klaytnAddress(VALID_OWNER_ADDRESS2)
                 .nickname("조엘")
                 .phoneNumber("010-8516-1399")
                 .privacyAgreement(true)

--- a/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
+++ b/src/test/java/com/backend/connectable/kas/service/KasServiceTest.java
@@ -10,10 +10,7 @@ import com.backend.connectable.kas.service.contract.dto.ContractItemResponse;
 import com.backend.connectable.kas.service.contract.dto.ContractItemsResponse;
 import com.backend.connectable.kas.service.mockserver.KasMockRequest;
 import com.backend.connectable.kas.service.mockserver.KasServiceMockSetup;
-import com.backend.connectable.kas.service.token.dto.TokenHistoriesResponse;
-import com.backend.connectable.kas.service.token.dto.TokenIdentifier;
-import com.backend.connectable.kas.service.token.dto.TokenResponse;
-import com.backend.connectable.kas.service.token.dto.TokensResponse;
+import com.backend.connectable.kas.service.token.dto.*;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -284,7 +281,7 @@ class KasServiceTest extends KasServiceMockSetup {
         // given
         String contractAddress1 = KasMockRequest.VALID_CONTRACT_ADDRESS;
         String contractAddress2 = KasMockRequest.VALID_CONTRACT_ADDRESS2;
-        List<String> contractAddresses = Arrays.asList(contractAddress1, contractAddress2);
+        List<String> contractAddresses = List.of(contractAddress1, contractAddress2);
         String owner = KasMockRequest.VALID_OWNER_ADDRESS;
 
         // when
@@ -308,5 +305,25 @@ class KasServiceTest extends KasServiceMockSetup {
 
         // then
         assertThat(isHolder).isFalse();
+    }
+
+    @DisplayName("컨트랙트 주소와 클레이튼 주소로, 클레이튼 주소에 따라 들고 있는 토큰 정보를 얻을 수 있다.")
+    @Test
+    void findTokenHoldingStatus() {
+        // given
+        String contractAddress1 = KasMockRequest.VALID_CONTRACT_ADDRESS;
+        String contractAddress2 = KasMockRequest.VALID_CONTRACT_ADDRESS2;
+        List<String> contractAddresses = List.of(contractAddress1, contractAddress2);
+        String owner1 = KasMockRequest.VALID_OWNER_ADDRESS;
+        String owner2 = KasMockRequest.VALID_OWNER_ADDRESS2;
+        List<String> owners = List.of(owner1, owner2);
+
+        // when
+        TokenIdentifierByKlaytnAddress tokenHoldingStatus =
+                kasService.findTokenHoldingStatus(contractAddresses, owners);
+
+        // then
+        assertThat(tokenHoldingStatus.isHolder(owner1)).isTrue();
+        assertThat(tokenHoldingStatus.isHolder(owner2)).isTrue();
     }
 }

--- a/src/test/java/com/backend/connectable/kas/service/mockserver/KasMockRequest.java
+++ b/src/test/java/com/backend/connectable/kas/service/mockserver/KasMockRequest.java
@@ -27,6 +27,7 @@ public class KasMockRequest {
     public static String VALID_ALIAS = "alias";
 
     public static String VALID_OWNER_ADDRESS = "0xabcd";
+    public static String VALID_OWNER_ADDRESS2 = "0x8u8u";
     public static String INVALID_OWNER_ADDRESS = "0xefgh";
 
     private static final String GET = "GET";
@@ -77,7 +78,7 @@ public class KasMockRequest {
                     .withMethod(DELETE)
                     .withPath("/contract/" + VALID_CONTRACT_ADDRESS + "/token/" + VALID_TOKEN_ID);
 
-    public static HttpRequest GET_TOKENS_OF_USER =
+    public static HttpRequest GET_TOKENS_OF_USER_CONTRACT_ADDRESS_1 =
             request()
                     .withMethod(GET)
                     .withPath(
@@ -86,7 +87,7 @@ public class KasMockRequest {
                                     + "/owner/"
                                     + VALID_OWNER_ADDRESS);
 
-    public static HttpRequest GET_TOKENS_OF_USER2 =
+    public static HttpRequest GET_TOKENS_OF_USER_CONTRACT_ADDRESS_2 =
             request()
                     .withMethod(GET)
                     .withPath(
@@ -95,6 +96,23 @@ public class KasMockRequest {
                                     + "/owner/"
                                     + VALID_OWNER_ADDRESS);
 
+    public static HttpRequest GET_TOKENS_OF_USER2_CONTRACT_ADDRESS_1 =
+            request()
+                    .withMethod(GET)
+                    .withPath(
+                            "/contract/"
+                                    + VALID_CONTRACT_ADDRESS
+                                    + "/owner/"
+                                    + VALID_OWNER_ADDRESS2);
+
+    public static HttpRequest GET_TOKENS_OF_USER2_CONTRACT_ADDRESS_2 =
+            request()
+                    .withMethod(GET)
+                    .withPath(
+                            "/contract/"
+                                    + VALID_CONTRACT_ADDRESS2
+                                    + "/owner/"
+                                    + VALID_OWNER_ADDRESS2);
     public static HttpRequest GET_TOKENS_OF_USER_NOT_HOLDING =
             request()
                     .withMethod(GET)

--- a/src/test/java/com/backend/connectable/kas/service/mockserver/KasServiceMockSetup.java
+++ b/src/test/java/com/backend/connectable/kas/service/mockserver/KasServiceMockSetup.java
@@ -47,12 +47,24 @@ public class KasServiceMockSetup {
                 KasMockRequest.POST_TOKEN_SEND_BY_INVALID_TOKEN_ID,
                 KasMockResponse.BAD_REQUEST_RESPONSE);
         setUpMockServerApi(KasMockRequest.DELETE_TOKEN, KasMockResponse.DELETE_TOKEN);
-        setUpMockServerApi(KasMockRequest.GET_TOKENS_OF_USER, KasMockResponse.GET_TOKENS_OF_USER);
+        setUpMockServerApi(
+                KasMockRequest.GET_TOKENS_OF_USER_CONTRACT_ADDRESS_1,
+                KasMockResponse.GET_TOKENS_OF_USER);
         setUpMockServerApi(
                 KasMockRequest.GET_TOKENS_OF_USER_BY_INVALID_OWNER_ADDRESS,
                 KasMockResponse.BAD_REQUEST_RESPONSE);
-        setUpMockServerApi(KasMockRequest.GET_TOKENS_OF_USER, KasMockResponse.GET_TOKENS_OF_USER);
-        setUpMockServerApi(KasMockRequest.GET_TOKENS_OF_USER2, KasMockResponse.GET_TOKENS_OF_USER2);
+        setUpMockServerApi(
+                KasMockRequest.GET_TOKENS_OF_USER_CONTRACT_ADDRESS_1,
+                KasMockResponse.GET_TOKENS_OF_USER);
+        setUpMockServerApi(
+                KasMockRequest.GET_TOKENS_OF_USER_CONTRACT_ADDRESS_2,
+                KasMockResponse.GET_TOKENS_OF_USER2);
+        setUpMockServerApi(
+                KasMockRequest.GET_TOKENS_OF_USER2_CONTRACT_ADDRESS_1,
+                KasMockResponse.GET_TOKENS_OF_USER);
+        setUpMockServerApi(
+                KasMockRequest.GET_TOKENS_OF_USER2_CONTRACT_ADDRESS_2,
+                KasMockResponse.GET_TOKENS_OF_USER2);
         setUpMockServerApi(
                 KasMockRequest.GET_TOKENS_OF_USER_NOT_HOLDING,
                 KasMockResponse.GET_TOKENS_OF_USER_NOT_HOLDING);


### PR DESCRIPTION
## 작업 내용
- 아 빡셌습니다... 규모가 큰 PR이 될테니 살펴봐주십숑
1. **아티스트 댓글 조회 시 티켓 정보 반환을 구현합니다**
    - 유저가 가지고 있는 티켓에 대한 정보는 우리 RDB에 없습니다. 클레이튼을 갔다와야합니다.
    - 따라서 KasService를 갔다오는데요. 로직을 설명드리면 아래와 같습니다. 
        - List<ArtistComment\> undeletedArtistComments로 삭제 안된 댓글 조회
        - 아티스트가 발행한 이벤트 컨트랙트 주소 + 삭제 안된 댓글의 작성자 클레이튼 주소로, 클레이튼 주소에 대응되는 아티스트의 이벤트 토큰이 있는지 kas에 질의 (반환값: TokenIdentifierByKlaytnAddress)
        - 삭제 안된 댓글 조회를 순회하면서 TokenIdentifierByKlaytnAddress에 작성자의 클레이튼 주소가 있다면 티켓 정보를 조회해 추가하기. 없다면 누락시키기
        - 결과로 만든 List<ArtistComment\> holderArtistComments를 dto로 변환

## 주의 사항
- 우선 KAS API를 찌르는 로직은 비동기로 처리해서 엄청 오래걸릴 것 같진 않지만, 측정은 좀 해야할 것 같아서 TimeCheck를 붙였습니다
- 서비스 로직이 비대해졌네요. 피드백 부탁드립니다!

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
